### PR TITLE
Update to 0.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(aic-sdk-cpp VERSION 0.11.0 LANGUAGES C CXX)
+project(aic-sdk-cpp VERSION 0.12.0 LANGUAGES C CXX)
 
 option(AIC_SDK_ALLOW_DOWNLOAD "Allow C SDK download at configure time" OFF)
 option(AIC_SDK_USE_STATIC "Link against static aic C SDK" ON)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ set(AIC_SDK_ALLOW_DOWNLOAD ON CACHE BOOL "Allow C SDK download at configure time
 FetchContent_Declare(
         aic_sdk
         GIT_REPOSITORY https://github.com/ai-coustics/aic-sdk-cpp.git
-        GIT_TAG        0.11.0
+        GIT_TAG        0.12.0
         GIT_SHALLOW    TRUE
     )
 FetchContent_MakeAvailable(aic_sdk)
@@ -103,7 +103,7 @@ The ai-coustics Speech Enhancement SDK is available in multiple programming lang
 | **C** | [`aic-sdk-c`](https://github.com/ai-coustics/aic-sdk-c) | Core C-Interface |
 | **Python** | [`aic-sdk-py`](https://github.com/ai-coustics/aic-sdk-py) | Idiomatic Python interface |
 | **Rust** | [`aic-sdk-rs`](https://github.com/ai-coustics/aic-sdk-rs) | Safe Rust bindings with zero-cost abstractions |
-| **JavaScript/TypeScript** | [`aic-sdk-node`](https://github.com/ai-coustics/aic-sdk-node) | Native bindings for Node.js applications |
+| **JavaScript** | [`aic-sdk-node`](https://github.com/ai-coustics/aic-sdk-node) | Native bindings for Node.js applications |
 | **Web (WASM)** | [`aic-sdk-wasm`](https://github.com/ai-coustics/aic-sdk-wasm) | WebAssembly build for browser applications |
 
 All SDKs provide the same core functionality with language-specific optimizations and idioms.

--- a/checksum.txt
+++ b/checksum.txt
@@ -1,6 +1,6 @@
-695983d752935e2e386101a8304c9c0bd8b657608887b7be3e92b0222a6a9e58  aic-sdk-aarch64-apple-darwin-0.11.0.tar.gz
-370cbc122b20c37e35164a06dc11d1683cee31463aba305cbaba281276f8344c  aic-sdk-aarch64-unknown-linux-gnu-0.11.0.tar.gz
-2b1a72a1f644ef38b79e0204bed2b4f275d0bbda7c55d7fa2f3dff83d5fc8791  aic-sdk-x86_64-apple-darwin-0.11.0.tar.gz
-825ec88bde5ed2401bb75dc63ce2f7777dd135fa402f59f06c8b0cacaa6da2a0  aic-sdk-x86_64-unknown-linux-gnu-0.11.0.tar.gz
-7fd397f8f660689503c2b17da653e292ca831268a33f0cd48a7f49e98ba87d9a  aic-sdk-aarch64-pc-windows-msvc-0.11.0.zip
-34d71e0bf26d249f63fd0976ad8029e9420d3ecfb33fef7b1e8c8dfaf4fe06f2  aic-sdk-x86_64-pc-windows-msvc-0.11.0.zip
+a6a6706ee38437f8ee90c1175eb7509ef48f1b70bf65a2a23e8a308cc378fde7  aic-sdk-aarch64-apple-darwin-0.12.0.tar.gz
+79203f1744df59b8dcfe97a3f50962395bafe04823c74b6e4f88c018ecc12fce  aic-sdk-aarch64-unknown-linux-gnu-0.12.0.tar.gz
+55c868a6102c55188c57f50dce74676a7aa49540e157591bb68a7b9cf88e7942  aic-sdk-x86_64-apple-darwin-0.12.0.tar.gz
+41c387d5213c69b64a76fcaa0140dd87fa3f18ec2774ecdb13b63128960482c5  aic-sdk-x86_64-unknown-linux-gnu-0.12.0.tar.gz
+c17dc3f5de294a53f4930cba1dfdc30963e10e6fdbf80852e1c9ca0d34cabbbc  aic-sdk-aarch64-pc-windows-msvc-0.12.0.zip
+94bff930225f468b839f8fd80cb9c5b959f2cf5c3908d5b7a63dd3882b102d3b  aic-sdk-x86_64-pc-windows-msvc-0.12.0.zip

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
     FetchContent_Declare(
         aic_sdk
         GIT_REPOSITORY https://github.com/ai-coustics/aic-sdk-cpp.git
-        GIT_TAG        0.11.0
+        GIT_TAG        0.12.0
         GIT_SHALLOW    TRUE
     )
     FetchContent_MakeAvailable(aic_sdk)

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -52,10 +52,10 @@ int main()
     }
 
     // Set VAD parameters
-    vad_err = vad->set_parameter(aic::VadParameter::LookbackBufferSize, 5.0f);
+    vad_err = vad->set_parameter(aic::VadParameter::SpeechHoldDuration, 0.1f);
     if (vad_err != aic::ErrorCode::Success)
     {
-        std::cerr << "Failed to set VAD lookback buffer size\n";
+        std::cerr << "Failed to set VAD speech hold duration\n";
         return 1;
     }
 
@@ -67,9 +67,9 @@ int main()
     }
 
     // Get VAD parameter values
-    float lookback = vad->get_parameter(aic::VadParameter::LookbackBufferSize);
+    float lookback = vad->get_parameter(aic::VadParameter::SpeechHoldDuration);
     float sensitivity = vad->get_parameter(aic::VadParameter::Sensitivity);
-    std::cout << "VAD lookback buffer size: " << lookback << "\n";
+    std::cout << "VAD speech hold duration: " << lookback << "\n";
     std::cout << "VAD sensitivity: " << sensitivity << "\n";
 
     // Test all available parameters

--- a/include/aic.hpp
+++ b/include/aic.hpp
@@ -97,10 +97,12 @@ enum class EnhancementParameter : int
 /// Configurable parameters for voice activity detection (VAD)
 enum class VadParameter : int
 {
-    /// Controls the lookback buffer size used in the Voice Activity Detector. (1.0-20.0)
-    LookbackBufferSize = AIC_VAD_PARAMETER_LOOKBACK_BUFFER_SIZE,
+    /// Controls for how long the VAD continues to detect speech after the audio signal no longer contains speech. (0.0 to 20x model window length in seconds)
+    SpeechHoldDuration = AIC_VAD_PARAMETER_SPEECH_HOLD_DURATION,
     /// Controls the sensitivity (energy threshold) of the VAD. (1.0-15.0)
     Sensitivity = AIC_VAD_PARAMETER_SENSITIVITY,
+    /// Controls for how long speech needs to be present in the audio signal before the VAD considers it speech (0.0 - 1.0 seconds).
+    MinimumSpeechDuration = AIC_VAD_PARAMETER_MINIMUM_SPEECH_DURATION,
 };
 
 // ---------------------------

--- a/release/ReleaseNotes.md
+++ b/release/ReleaseNotes.md
@@ -1,17 +1,7 @@
-# Release Notes
-
 ### Features
 
-- **Quail Voice Focus STT** (`Quail_VF_STT_L16`): Purpose-built to isolate and elevate the foreground speaker while suppressing both interfering speech and background noise.
-- **New Quail STT model variants**: Added `Quail_STT_L8`, `Quail_STT_S16`, and `Quail_STT_S8` to provide additional model size and sample rate options.
-- **Sequential channel processing**: Added `process_sequential` method for processing sequential channel data in a single buffer.
-
+- **New VAD parameter `VadParameter::MinimumSpeechDuration`**: Controls for how long speech needs to be present in the audio signal before the VAD considers it speech (0.0 - 1.0 seconds).
 
 ### Breaking Changes
 
-- **Renamed `Quail_STT` to `Quail_STT_L16`**: The original Quail STT model type has been renamed for consistency with the new model variants.
-- **Changed `AicVad::create` signature**: The `model` parameter is no longer `const`.
-
-### Fixes
-
-- **VAD compatibility with enhancement bypass**: VAD now works correctly when `EnhancementLevel` is set to 0 or `Bypass` is enabled (previously non-functional in these cases).
+- **Replaced VAD parameter `VadParameter::LookbackBufferSize` with `VadParameter::SpeechHoldDuration`**: The new parameter controls for how long the VAD continues to detect speech after the audio signal no longer contains speech (0.0 to 20x model window length in seconds).


### PR DESCRIPTION
### Features

- **New VAD parameter `VadParameter::MinimumSpeechDuration`**: Controls for how long speech needs to be present in the audio signal before the VAD considers it speech (0.0 - 1.0 seconds).

### Breaking Changes

- **Replaced VAD parameter `VadParameter::LookbackBufferSize` with `VadParameter::SpeechHoldDuration`**: The new parameter controls for how long the VAD continues to detect speech after the audio signal no longer contains speech (0.0 to 20x model window length in seconds).
