### PR TITLE
Release 0.14.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,24 @@ jobs:
       - name: Build
         run: cmake --build build -j
 
+      - name: Download model (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir -p build/models
+          curl -L -o build/models/sparrow_xxs_48khz_wsur2zkw_v7.aicmodel \
+            https://artifacts.ai-coustics.io/models/sparrow-xxs-48khz/v1/sparrow_xxs_48khz_wsur2zkw_v7.aicmodel
+
+      - name: Download model (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force -Path build\\models | Out-Null
+          Invoke-WebRequest -Uri "https://artifacts.ai-coustics.io/models/sparrow-xxs-48khz/v1/sparrow_xxs_48khz_wsur2zkw_v7.aicmodel" -OutFile "build\\models\\sparrow_xxs_48khz_wsur2zkw_v7.aicmodel"
+
       - name: Run Example (Linux/macOS)
         if: runner.os != 'Windows'
-        run: ./build/my_app
+        run: ./build/my_app build/models/sparrow_xxs_48khz_wsur2zkw_v7.aicmodel
 
       - name: Run Example (Windows)
         if: runner.os == 'Windows'
-        run: .\build\Debug\my_app.exe
+        run: .\build\Debug\my_app.exe build\models\sparrow_xxs_48khz_wsur2zkw_v7.aicmodel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(aic-sdk-cpp VERSION 0.12.0 LANGUAGES C CXX)
+project(aic-sdk-cpp VERSION 0.13.0 LANGUAGES C CXX)
 
 option(AIC_SDK_ALLOW_DOWNLOAD "Allow C SDK download at configure time" OFF)
 option(AIC_SDK_USE_STATIC "Link against static aic C SDK" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(aic-sdk-cpp VERSION 0.13.0 LANGUAGES C CXX)
+project(aic-sdk-cpp VERSION 0.14.0 LANGUAGES C CXX)
 
 option(AIC_SDK_ALLOW_DOWNLOAD "Allow C SDK download at configure time" OFF)
 option(AIC_SDK_USE_STATIC "Link against static aic C SDK" ON)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ set(AIC_SDK_ALLOW_DOWNLOAD ON CACHE BOOL "Allow C SDK download at configure time
 FetchContent_Declare(
     aic_sdk
     GIT_REPOSITORY https://github.com/ai-coustics/aic-sdk-cpp.git
-    GIT_TAG        0.13.0
+    GIT_TAG        0.14.0
     GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(aic_sdk)

--- a/README.md
+++ b/README.md
@@ -96,11 +96,10 @@ The wrapper is fully C++11 compatible and on Linux you will need at least GLIBC 
 
 ## Running the Example
 
-To run the example, make sure you have set your license key and model path as environment variables:
+To run the example, make sure you have set your license key in an environment variable:
 
 ```bash
 export AIC_SDK_LICENSE="your_license_key_here"
-export AIC_SDK_MODEL_PATH="/path/to/model.aicmodel"
 ```
 
 Then use the following commands to configure, build and run the example (you can also pass the model path as the first argument):
@@ -108,7 +107,7 @@ Then use the following commands to configure, build and run the example (you can
 ```sh
 cmake -B build ./example
 cmake --build build -j
-./build/my_app
+./build/my_app /path/to/model.aicmodel
 ```
 
 ## Support & Resources

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ set(AIC_SDK_ALLOW_DOWNLOAD ON CACHE BOOL "Allow C SDK download at configure time
 FetchContent_Declare(
         aic_sdk
         GIT_REPOSITORY https://github.com/ai-coustics/aic-sdk-cpp.git
-        GIT_TAG        0.12.0
+        GIT_TAG        0.13.0
         GIT_SHALLOW    TRUE
     )
 FetchContent_MakeAvailable(aic_sdk)
@@ -43,27 +43,34 @@ Here's a simple example showing the core SDK workflow. Error handling is omitted
 
 #include <vector>
 #include <cstdlib>
+#include <utility>
 
 int main() {
     // Load your license key
     const char* license = std::getenv("AIC_SDK_LICENSE");
 
-    // Create a new model
-    auto creation_result = aic::AicModel::create(aic::ModelType::Quail_S48, license);
-    std::unique_ptr<aic::AicModel>& model = creation_result.first;
+    // Create a new model from a file path
+    aic::Result<aic::Model> model_result = aic::Model::create_from_file("/path/to/model.aicmodel");
+    aic::Model model = std::move(model_result.value);
 
-    // Initialize with your audio settings
-    model->initialize(48000, 2, 480, false);
+    // Create a processor and initialize with your audio settings
+    auto processor_result = aic::Processor::create(model, license);
+    aic::Processor processor = std::move(processor_result.value);
+    aic::ProcessorConfig config = aic::ProcessorConfig::optimal(model).with_num_channels(2);
+    processor->initialize(config.sample_rate, config.num_channels, config.num_frames,
+                          config.allow_variable_frames);
 
-    // Configure enhancement parameters
-    model->set_parameter(aic::Parameter::EnhancementLevel, 0.7f);
+    // Configure enhancement parameters via a processor context
+    auto ctx_result = processor.create_context();
+    aic::ProcessorContext ctx = std::move(ctx_result.value);
+    ctx.set_parameter(aic::ProcessorParameter::EnhancementLevel, 0.7f);
 
     // Process audio (interleaved version available as well)
-    std::vector<float> audio_buffer_left(480, 0.0f);
-    std::vector<float> audio_buffer_right(480, 0.0f);
+    std::vector<float> audio_buffer_left(config.num_frames, 0.0f);
+    std::vector<float> audio_buffer_right(config.num_frames, 0.0f);
     std::vector<float*> audio_buffer_planar = {audio_buffer_left.data(), audio_buffer_right.data()};
 
-    model->process_planar(audio_buffer_planar.data(), 2, 480);
+    processor.process_planar(audio_buffer_planar.data(), 2, config.num_frames);
 
     return 0;
 }
@@ -75,13 +82,14 @@ The wrapper is fully C++11 compatible and on Linux you will need at least GLIBC 
 
 ## Running the Example
 
-To run the example, make sure you have set your license key as an environment variable:
+To run the example, make sure you have set your license key and model path as environment variables:
 
 ```bash
 export AIC_SDK_LICENSE="your_license_key_here"
+export AIC_SDK_MODEL_PATH="/path/to/model.aicmodel"
 ```
 
-Then use the following commands to configure, build and run the example:
+Then use the following commands to configure, build and run the example (you can also pass the model path as the first argument):
 
 ```sh
 cmake -B build ./example

--- a/README.md
+++ b/README.md
@@ -51,18 +51,18 @@ int main() {
 
     // Create a new model from a file path
     aic::Result<aic::Model> model_result = aic::Model::create_from_file("/path/to/model.aicmodel");
-    aic::Model model = std::move(model_result.value);
+    aic::Model model = model_result.take();
 
     // Create a processor and initialize with your audio settings
     auto processor_result = aic::Processor::create(model, license);
-    aic::Processor processor = std::move(processor_result.value);
+    aic::Processor processor = processor_result.take();
     aic::ProcessorConfig config = aic::ProcessorConfig::optimal(model).with_num_channels(2);
     processor->initialize(config.sample_rate, config.num_channels, config.num_frames,
                           config.allow_variable_frames);
 
     // Configure enhancement parameters via a processor context
     auto ctx_result = processor.create_context();
-    aic::ProcessorContext ctx = std::move(ctx_result.value);
+    aic::ProcessorContext ctx = ctx_result.take();
     ctx.set_parameter(aic::ProcessorParameter::EnhancementLevel, 0.7f);
 
     // Process audio (interleaved version available as well)

--- a/README.md
+++ b/README.md
@@ -1,22 +1,15 @@
-# ai-coustics Speech Enhancement SDK for C++
+# aic-sdk-cpp - C++ Bindings for ai-coustics SDK
 
-A modern C++ wrapper around the ai-coustics Speech Enhancement SDK, providing type-safe enums and RAII resource management while maintaining a thin layer over the underlying C API.
+C++ wrapper for the ai-coustics Speech Enhancement SDK.
 
-## What is this SDK?
+For comprehensive documentation, visit [docs.ai-coustics.com](https://docs.ai-coustics.com).
 
-Our Speech Enhancement SDK delivers state-of-the-art audio processing capabilities, enabling you to enhance speech clarity and intelligibility in real-time.
+> [!NOTE]
+> This SDK requires a license key. Generate your key at [developers.ai-coustics.io](https://developers.ai-coustics.io).
 
-## Quick Start
-
-### Generate your SDK License Key
-
-To use this SDK, you'll need to generate an **SDK license key** from our [Development Portal](https://developers.ai-coustics.io).
-
-**Please note:** The SDK license key is different from our cloud API product. If you have an API license key for our cloud services, it won't work with the SDK - you'll need to create a separate SDK license key in the portal.
+## Installation
 
 ### CMake Integration
-
-With this CMake example you can add the SDK to your application and let CMake download all necessary files automatically:
 
 ```cmake
 include(FetchContent)
@@ -34,75 +27,234 @@ FetchContent_MakeAvailable(aic_sdk)
 target_link_libraries(my_app PRIVATE aic-sdk)
 ```
 
-### Example Usage
-
-Here's a simple example showing the core SDK workflow. Error handling is omitted for clarity - see the [complete example](example/main.cpp) for production-ready code:
+## Quick Start
 
 ```cpp
 #include "aic.hpp"
 
 #include <vector>
 #include <cstdlib>
-#include <utility>
 
 int main() {
-    // Load your license key
-    const char* license = std::getenv("AIC_SDK_LICENSE");
-    if (!license || *license == '\0') {
-        return 1;
-    }
+    // Get your license key from the environment variable
+    const char* license_key = std::getenv("AIC_SDK_LICENSE");
 
-    // Create a new model from a file path
-    auto model_result = aic::Model::create_from_file("/path/to/model.aicmodel");
-    if (!model_result.ok()) {
-        return 1;
-    }
-    auto model = model_result.take();
+    // Load a model from file (download models at https://artifacts.ai-coustics.io/)
+    auto model = aic::Model::create_from_file("./models/model.aicmodel").take();
 
-    // Create a processor and initialize with your audio settings
-    auto processor_result = aic::Processor::create(model, license);
-    if (!processor_result.ok()) {
-        return 1;
-    }
+    // Create configuration with model's optimal settings
+    auto sample_rate = model.get_optimal_sample_rate();
+    auto num_frames = model.get_optimal_num_frames(sample_rate);
+    aic::ProcessorConfig config(sample_rate, num_frames, 2);  // 2 channels (stereo)
 
-    auto processor = processor_result.take();
-    auto config = aic::ProcessorConfig::optimal(model).with_num_channels(2);
+    // Create and initialize processor
+    auto processor = aic::Processor::create(model, license_key).take();
     processor.initialize(config.sample_rate, config.num_channels, config.num_frames,
                          config.allow_variable_frames);
 
-    // Configure enhancement parameters via a processor context
-    auto ctx_result = processor.create_context();
-    if (!ctx_result.ok()) {
-        return 1;
-    }
-
-    auto ctx = ctx_result.take();
-    ctx.set_parameter(aic::ProcessorParameter::EnhancementLevel, 0.7f);
-
-    // Process audio (interleaved version available as well)
-    std::vector<float> audio_buffer_left(config.num_frames, 0.0f);
-    std::vector<float> audio_buffer_right(config.num_frames, 0.0f);
-    std::vector<float*> audio_buffer_planar = {audio_buffer_left.data(), audio_buffer_right.data()};
-
-    processor.process_planar(audio_buffer_planar.data(), 2, config.num_frames);
+    // Process audio (planar layout: separate buffer per channel)
+    std::vector<float> left(config.num_frames, 0.0f);
+    std::vector<float> right(config.num_frames, 0.0f);
+    std::vector<float*> audio = {left.data(), right.data()};
+    processor.process_planar(audio.data(), config.num_channels, config.num_frames);
 
     return 0;
 }
 ```
 
-### Compatibility
+## Usage
 
-The wrapper is fully C++11 compatible and on Linux you will need at least GLIBC 2.27 / Ubuntu 18.04.
+### SDK Information
 
-## Running the Example
+```cpp
+// Get SDK version
+std::cout << "SDK version: " << aic::get_sdk_version() << "\n";
 
-To run the example, make sure you have set your license key in an environment variable:
+// Get compatible model version
+std::cout << "Compatible model version: " << aic::get_compatible_model_version() << "\n";
+```
+
+### Loading Models
+
+Download models and find available IDs at [artifacts.ai-coustics.io](https://artifacts.ai-coustics.io/).
+
+#### From File
+```cpp
+auto result = aic::Model::create_from_file("path/to/model.aicmodel");
+if (!result.ok()) {
+    // Handle error using result.error
+}
+auto model = result.take();
+```
+
+#### From Memory Buffer
+```cpp
+// Buffer must be 64-byte aligned and remain valid for the model's lifetime
+auto result = aic::Model::create_from_buffer(buffer_ptr, buffer_size);
+if (!result.ok()) {
+    // Handle error using result.error
+}
+auto model = result.take();
+```
+
+### Model Information
+
+```cpp
+// Get model ID
+std::string model_id = model.get_id();
+
+// Get optimal sample rate for the model
+uint32_t optimal_rate = model.get_optimal_sample_rate();
+
+// Get optimal frame count for a specific sample rate
+size_t optimal_frames = model.get_optimal_num_frames(48000);
+```
+
+### Configuring the Processor
+
+```cpp
+// Query optimal settings from the model
+auto sample_rate = model.get_optimal_sample_rate();
+auto num_frames = model.get_optimal_num_frames(sample_rate);
+
+// Create configuration with optimal settings
+aic::ProcessorConfig config(sample_rate, num_frames);  // mono, fixed frames
+// Or customize: stereo with variable frames
+aic::ProcessorConfig config(sample_rate, num_frames, 2, true);
+
+// Or use custom values entirely
+aic::ProcessorConfig config(48000, 480, 2, false);
+
+// Create processor with license key
+auto processor = aic::Processor::create(model, license_key).take();
+
+// Initialize with configuration
+processor.initialize(config.sample_rate, config.num_channels, config.num_frames,
+                     config.allow_variable_frames);
+```
+
+### Processing Audio
+
+The SDK supports three audio buffer layouts for in-place processing:
+
+#### Planar (Separate Buffer per Channel)
+```cpp
+// Each channel in its own buffer
+std::vector<float> left(num_frames, 0.0f);
+std::vector<float> right(num_frames, 0.0f);
+std::vector<float*> audio = {left.data(), right.data()};
+
+processor.process_planar(audio.data(), num_channels, num_frames);
+```
+
+#### Interleaved (Alternating Samples)
+```cpp
+// [L0, R0, L1, R1, L2, R2, ...]
+std::vector<float> audio(num_channels * num_frames);
+
+processor.process_interleaved(audio.data(), num_channels, num_frames);
+```
+
+#### Sequential (Channel Data Concatenated)
+```cpp
+// [L0, L1, L2, ..., R0, R1, R2, ...]
+std::vector<float> audio(num_channels * num_frames);
+
+processor.process_sequential(audio.data(), num_channels, num_frames);
+```
+
+### Processor Context
+
+```cpp
+// Get processor context
+auto ctx = processor.create_context().take();
+
+// Get output delay in samples
+size_t delay = ctx.get_output_delay();
+
+// Reset processor state (clears internal buffers)
+ctx.reset();
+
+// Set enhancement parameters
+ctx.set_parameter(aic::ProcessorParameter::EnhancementLevel, 0.8f);
+ctx.set_parameter(aic::ProcessorParameter::VoiceGain, 1.5f);
+ctx.set_parameter(aic::ProcessorParameter::Bypass, 1.0f);
+
+// Get parameter values
+float level = ctx.get_parameter(aic::ProcessorParameter::EnhancementLevel);
+std::cout << "Enhancement level: " << level << "\n";
+```
+
+### Voice Activity Detection (VAD)
+
+```cpp
+// Get VAD context from processor
+auto vad = processor.create_vad_context().take();
+
+// Configure VAD parameters
+vad.set_parameter(aic::VadParameter::Sensitivity, 6.0f);
+vad.set_parameter(aic::VadParameter::SpeechHoldDuration, 0.05f);
+vad.set_parameter(aic::VadParameter::MinimumSpeechDuration, 0.0f);
+
+// Get parameter values
+float sensitivity = vad.get_parameter(aic::VadParameter::Sensitivity);
+std::cout << "VAD sensitivity: " << sensitivity << "\n";
+
+// Check for speech (after processing audio through the processor)
+if (vad.is_speech_detected()) {
+    std::cout << "Speech detected!\n";
+}
+```
+
+### Error Handling
+
+The SDK uses a `Result<T>` type for operations that can fail. All error conditions are represented by the `aic::ErrorCode` enum.
+
+#### Checking Results
+
+```cpp
+auto result = aic::Model::create_from_file("path/to/model.aicmodel");
+if (!result.ok()) {
+    switch (result.error) {
+        case aic::ErrorCode::ModelFilePathInvalid:
+            std::cerr << "Invalid model path\n";
+            break;
+        case aic::ErrorCode::ModelInvalid:
+            std::cerr << "Invalid model file\n";
+            break;
+        case aic::ErrorCode::ModelVersionUnsupported:
+            std::cerr << "Model version not supported\n";
+            break;
+        default:
+            std::cerr << "Error code: " << static_cast<int>(result.error) << "\n";
+    }
+    return 1;
+}
+auto model = result.take();
+```
+
+#### Common Error Codes
+
+| Error Code | Description |
+|------------|-------------|
+| `LicenseFormatInvalid` | License key format is invalid or corrupted |
+| `LicenseExpired` | License key has expired |
+| `LicenseVersionUnsupported` | License version not compatible with SDK |
+| `ModelInvalid` | Model file is invalid or corrupted |
+| `ModelVersionUnsupported` | Model version not compatible with SDK |
+| `ModelFilePathInvalid` | Path to model file is invalid |
+| `AudioConfigUnsupported` | Audio configuration not supported by model |
+| `ParameterOutOfRange` | Parameter value outside acceptable range |
+
+## Building and Running the Example
+
+Set your license key in an environment variable:
 
 ```bash
 export AIC_SDK_LICENSE="your_license_key_here"
 ```
 
-Then use the following commands to configure, build and run the example (you can also pass the model path as the first argument):
+Build and run the example:
 
 ```sh
 cmake -B build ./example
@@ -110,36 +262,20 @@ cmake --build build -j
 ./build/my_app /path/to/model.aicmodel
 ```
 
-## Support & Resources
+### Compatibility
 
-### Documentation
-- **[Basic Example](example/main.cpp)** - Sample code and integration patterns
-- **[CMake Integration Guide](example/CMakeLists.txt)** - Build configuration and SDK integration
+The wrapper is fully C++11 compatible. On Linux, you will need at least GLIBC 2.27 (Ubuntu 18.04).
 
-### Looking for Other Languages?
-The ai-coustics Speech Enhancement SDK is available in multiple programming languages to fit your development needs:
+## Examples
 
-| Platform | Repository | Description |
-|----------|------------|-------------|
-| **C** | [`aic-sdk-c`](https://github.com/ai-coustics/aic-sdk-c) | Core C-Interface |
-| **Python** | [`aic-sdk-py`](https://github.com/ai-coustics/aic-sdk-py) | Idiomatic Python interface |
-| **Rust** | [`aic-sdk-rs`](https://github.com/ai-coustics/aic-sdk-rs) | Safe Rust bindings with zero-cost abstractions |
-| **JavaScript** | [`aic-sdk-node`](https://github.com/ai-coustics/aic-sdk-node) | Native bindings for Node.js applications |
-| **Web (WASM)** | [`aic-sdk-wasm`](https://github.com/ai-coustics/aic-sdk-wasm) | WebAssembly build for browser applications |
+See the [`example/main.cpp`](example/main.cpp) file for a complete working example demonstrating all SDK features including model loading, processor configuration, parameter adjustment, VAD usage, and all three audio processing layouts.
 
-All SDKs provide the same core functionality with language-specific optimizations and idioms.
+## Documentation
 
-### Demo Plugin
-Experience our speech enhancement models firsthand with our [Demo Plugin](https://github.com/ai-coustics/aic-sdk-plugin) - a complete audio plugin that showcases all available models while serving as a comprehensive C++ integration example.
-
-### Get Help
-Need assistance? We're here to support you:
-- **Issues**: [GitHub Issues](https://github.com/ai-coustics/aic-sdk-cpp/issues)
-- **Technical Support**: [info@ai-coustics.com](mailto:info@ai-coustics.com)
+- **Full Documentation**: [docs.ai-coustics.com](https://docs.ai-coustics.com)
+- **C++ API Reference**: See the [header file](include/aic.hpp) for detailed type information
+- **Available Models**: [artifacts.ai-coustics.io](https://artifacts.ai-coustics.io)
 
 ## License
-This C++ wrapper is distributed under the [Apache 2.0 license](LICENSE), while the core C SDK is distributed under the proprietary [AIC-SDK license](LICENSE.AIC-SDK).
 
----
-
-Made with ❤️ by the ai-coustics team
+This C++ wrapper is distributed under the Apache 2.0 license. The core C SDK is distributed under the proprietary AIC-SDK license.

--- a/checksum.txt
+++ b/checksum.txt
@@ -1,6 +1,6 @@
-a6a6706ee38437f8ee90c1175eb7509ef48f1b70bf65a2a23e8a308cc378fde7  aic-sdk-aarch64-apple-darwin-0.12.0.tar.gz
-79203f1744df59b8dcfe97a3f50962395bafe04823c74b6e4f88c018ecc12fce  aic-sdk-aarch64-unknown-linux-gnu-0.12.0.tar.gz
-55c868a6102c55188c57f50dce74676a7aa49540e157591bb68a7b9cf88e7942  aic-sdk-x86_64-apple-darwin-0.12.0.tar.gz
-41c387d5213c69b64a76fcaa0140dd87fa3f18ec2774ecdb13b63128960482c5  aic-sdk-x86_64-unknown-linux-gnu-0.12.0.tar.gz
-c17dc3f5de294a53f4930cba1dfdc30963e10e6fdbf80852e1c9ca0d34cabbbc  aic-sdk-aarch64-pc-windows-msvc-0.12.0.zip
-94bff930225f468b839f8fd80cb9c5b959f2cf5c3908d5b7a63dd3882b102d3b  aic-sdk-x86_64-pc-windows-msvc-0.12.0.zip
+65bf9526cf88732526a1b9fbec766976779ba849554b939e5939569772c2e379  aic-sdk-aarch64-apple-darwin-0.13.1.tar.gz
+a5212ab4757aabb7654980aeb1701838e6bdd4e3ad19a51b523708f8d40b4457  aic-sdk-aarch64-unknown-linux-gnu-0.13.1.tar.gz
+0b962c875ae54b0c5377030e5892ba4eb7b9cbc5ddde2985ba25c830c7091b2e  aic-sdk-x86_64-apple-darwin-0.13.1.tar.gz
+0b11717f441c41f8a217fecd3f200e6a7d24727289a546dba8e0483fb055f2f3  aic-sdk-x86_64-unknown-linux-gnu-0.13.1.tar.gz
+2e0579c7c6d91c61e21513a2e4e76afe0cf75516bc208db43b3ddb7bc328e11e  aic-sdk-aarch64-pc-windows-msvc-0.13.1.zip
+452b600604149b598898fd85ea023558d15c81a281b16d90390bd8462ffb4f16  aic-sdk-x86_64-pc-windows-msvc-0.13.1.zip

--- a/checksum.txt
+++ b/checksum.txt
@@ -1,6 +1,6 @@
-65bf9526cf88732526a1b9fbec766976779ba849554b939e5939569772c2e379  aic-sdk-aarch64-apple-darwin-0.13.1.tar.gz
-a5212ab4757aabb7654980aeb1701838e6bdd4e3ad19a51b523708f8d40b4457  aic-sdk-aarch64-unknown-linux-gnu-0.13.1.tar.gz
-0b962c875ae54b0c5377030e5892ba4eb7b9cbc5ddde2985ba25c830c7091b2e  aic-sdk-x86_64-apple-darwin-0.13.1.tar.gz
-0b11717f441c41f8a217fecd3f200e6a7d24727289a546dba8e0483fb055f2f3  aic-sdk-x86_64-unknown-linux-gnu-0.13.1.tar.gz
-2e0579c7c6d91c61e21513a2e4e76afe0cf75516bc208db43b3ddb7bc328e11e  aic-sdk-aarch64-pc-windows-msvc-0.13.1.zip
-452b600604149b598898fd85ea023558d15c81a281b16d90390bd8462ffb4f16  aic-sdk-x86_64-pc-windows-msvc-0.13.1.zip
+46d094413e9e962917da8d26a611db6f9d46e2e81e7be04dfb861830d9ca0655  aic-sdk-aarch64-apple-darwin-0.14.0.tar.gz
+9cf85c5e568ae38173b5fe08e450d2132d422dbcd814dc210cfd5dde4952fd1f  aic-sdk-aarch64-unknown-linux-gnu-0.14.0.tar.gz
+3efdbd8aee608ecb813995360fc30fee1117dc964591ac624d9fa687829be27e  aic-sdk-x86_64-apple-darwin-0.14.0.tar.gz
+f90d0802de482c060aa90f1cc51157938549c03b7bdbf0eec25d097d6d5f3309  aic-sdk-x86_64-unknown-linux-gnu-0.14.0.tar.gz
+c75469717598fe647e1dae604f9fb0f5166703a8dd7898ecbb481abf62a8ca1a  aic-sdk-aarch64-pc-windows-msvc-0.14.0.zip
+6ee08b6c0e15284197ebd7f01fe76517b8f0b5ebcdc2a96c6c714d120b348444  aic-sdk-x86_64-pc-windows-msvc-0.14.0.zip

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
     FetchContent_Declare(
         aic_sdk
         GIT_REPOSITORY https://github.com/ai-coustics/aic-sdk-cpp.git
-        GIT_TAG        0.12.0
+        GIT_TAG        0.13.0
         GIT_SHALLOW    TRUE
     )
     FetchContent_MakeAvailable(aic_sdk)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -36,3 +36,7 @@ add_executable(my_app main.cpp)
 
 # Link against the SDK
 target_link_libraries(my_app PRIVATE aic-sdk)
+
+if(APPLE)
+    target_link_libraries(my_app PRIVATE "-framework Security" "-framework CoreFoundation")
+endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
     FetchContent_Declare(
         aic_sdk
         GIT_REPOSITORY https://github.com/ai-coustics/aic-sdk-cpp.git
-        GIT_TAG        0.13.0
+        GIT_TAG        0.14.0
         GIT_SHALLOW    TRUE
     )
     FetchContent_MakeAvailable(aic_sdk)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -40,3 +40,7 @@ target_link_libraries(my_app PRIVATE aic-sdk)
 if(APPLE)
     target_link_libraries(my_app PRIVATE "-framework Security" "-framework CoreFoundation")
 endif()
+
+if(WIN32)
+    target_link_libraries(my_app PRIVATE crypt32)
+endif()

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -24,18 +24,10 @@ int main(int argc, char** argv)
     {
         model_path = argv[1];
     }
-    else
-    {
-        auto model_env = std::getenv("AIC_SDK_MODEL_PATH");
-        if (model_env && model_env[0] != '\0')
-        {
-            model_path = model_env;
-        }
-    }
 
     if (model_path.empty())
     {
-        std::cerr << "Error: Provide model path as argv[1] or set AIC_SDK_MODEL_PATH.\n";
+        std::cerr << "Error: Provide model path as argv[1]: `./my_app <model_path>`\n";
         return 1;
     }
 

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv)
     aic::Model model = model_result.take();
     auto config = aic::ProcessorConfig::optimal(model).with_num_channels(1);
 
-    aic::Result<aic::Processor> processor_result = aic::Processor::create(model_ref, license_key);
+    aic::Result<aic::Processor> processor_result = aic::Processor::create(model, license_key);
     err                                          = processor_result.error;
 
     if (!processor_result.ok())

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -41,7 +41,13 @@ int main(int argc, char** argv)
     }
 
     auto model  = model_result.take();
-    auto config = aic::ProcessorConfig::optimal(model).with_num_channels(1);
+
+    // Query optimal settings from the model
+    auto sample_rate = model.get_optimal_sample_rate();
+    auto num_frames = model.get_optimal_num_frames(sample_rate);
+
+    // Create configuration with optimal settings
+    aic::ProcessorConfig config(sample_rate, num_frames);  // mono, fixed frames
 
     auto processor_result = aic::Processor::create(model, license_key);
     err                   = processor_result.error;

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -2,10 +2,15 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <string>
+#include <utility>
 #include <vector>
 
-int main()
+int main(int argc, char** argv)
 {
+    std::cout << "ai-coustics SDK version: " << aic::get_sdk_version() << "\n";
+    std::cout << "Compatible model version: " << aic::get_compatible_model_version() << "\n";
+
     const char* license_env = std::getenv("AIC_SDK_LICENSE");
     if (!license_env || std::string(license_env).empty())
     {
@@ -14,121 +19,161 @@ int main()
     }
     std::string license_key(license_env);
 
-    auto creation_result = aic::AicModel::create(aic::ModelType::Quail_L48, license_key);
-    std::unique_ptr<aic::AicModel>& model = creation_result.first;
-    aic::ErrorCode                  err   = creation_result.second;
+    std::string model_path;
+    if (argc > 1 && argv[1] != nullptr)
+    {
+        model_path = argv[1];
+    }
+    else
+    {
+        const char* model_env = std::getenv("AIC_SDK_MODEL_PATH");
+        if (model_env && model_env[0] != '\0')
+        {
+            model_path = model_env;
+        }
+    }
 
-    if (err != aic::ErrorCode::Success)
+    if (model_path.empty())
+    {
+        std::cerr << "Error: Provide model path as argv[1] or set AIC_SDK_MODEL_PATH.\n";
+        return 1;
+    }
+
+    aic::Result<aic::Model> model_result = aic::Model::create_from_file(model_path);
+    aic::ErrorCode          err          = model_result.error;
+
+    if (!model_result.ok())
     {
         std::cerr << "Model creation failed with error code: " << static_cast<int>(err) << "\n";
         return 1;
     }
 
-    uint32_t sample_rate = model->get_optimal_sample_rate();
-    size_t   num_frames  = model->get_optimal_num_frames(sample_rate);
-    std::cout << "Optimal sample rate: " << sample_rate << " Hz\n";
-    std::cout << "Optimal number of frames: " << num_frames << "\n";
-    uint16_t num_chans = 1;
+    aic::Model model = std::move(model_result.value);
+    aic::Model& model_ref = model;
+    auto config = aic::ProcessorConfig::optimal(model_ref).with_num_channels(1);
 
-    err = model->initialize(sample_rate, num_chans, num_frames, false);
+    aic::Result<aic::Processor> processor_result = aic::Processor::create(model_ref, license_key);
+    err                                          = processor_result.error;
+
+    if (!processor_result.ok())
+    {
+        std::cerr << "Processor creation failed with error code: " << static_cast<int>(err) << "\n";
+        return 1;
+    }
+
+    aic::Processor processor = std::move(processor_result.value);
+    aic::Processor& processor_ref = processor;
+    err = processor_ref.initialize(config.sample_rate, config.num_channels, config.num_frames,
+                                   config.allow_variable_frames);
     if (err != aic::ErrorCode::Success)
     {
         std::cerr << "Initialization failed\n";
         return 1;
     }
 
-    size_t output_delay = model->get_output_delay();
-    std::cout << "Output delay: " << output_delay << " samples\n";
-
-    // Create and test VAD
-    auto vad_creation_result = aic::AicVad::create(*model);
-    std::unique_ptr<aic::AicVad>& vad = vad_creation_result.first;
-    aic::ErrorCode                vad_err = vad_creation_result.second;
-
-    if (vad_err != aic::ErrorCode::Success)
+    aic::Result<aic::ProcessorContext> ctx_result = processor_ref.create_context();
+    if (!ctx_result.ok())
     {
-        std::cerr << "VAD creation failed with error code: " << static_cast<int>(vad_err) << "\n";
+        std::cerr << "Processor context creation failed\n";
         return 1;
     }
 
-    // Set VAD parameters
-    vad_err = vad->set_parameter(aic::VadParameter::SpeechHoldDuration, 0.1f);
-    if (vad_err != aic::ErrorCode::Success)
+    aic::ProcessorContext ctx = std::move(ctx_result.value);
+    aic::ProcessorContext& ctx_ref = ctx;
+    size_t output_delay = ctx_ref.get_output_delay();
+    std::cout << "Output delay: " << output_delay << " samples\n";
+
+    aic::Result<aic::VadContext> vad_result = processor_ref.create_vad_context();
+    if (!vad_result.ok())
+    {
+        std::cerr << "VAD context creation failed\n";
+        return 1;
+    }
+
+    aic::VadContext vad = std::move(vad_result.value);
+    aic::VadContext& vad_ref = vad;
+    err = vad_ref.set_parameter(aic::VadParameter::SpeechHoldDuration, 0.1f);
+    if (err != aic::ErrorCode::Success)
     {
         std::cerr << "Failed to set VAD speech hold duration\n";
         return 1;
     }
 
-    vad_err = vad->set_parameter(aic::VadParameter::Sensitivity, 8.0f);
-    if (vad_err != aic::ErrorCode::Success)
+    err = vad_ref.set_parameter(aic::VadParameter::Sensitivity, 8.0f);
+    if (err != aic::ErrorCode::Success)
     {
         std::cerr << "Failed to set VAD sensitivity\n";
         return 1;
     }
 
-    // Get VAD parameter values
-    float lookback = vad->get_parameter(aic::VadParameter::SpeechHoldDuration);
-    float sensitivity = vad->get_parameter(aic::VadParameter::Sensitivity);
-    std::cout << "VAD speech hold duration: " << lookback << "\n";
+    float speech_hold_duration = vad_ref.get_parameter(aic::VadParameter::SpeechHoldDuration);
+    float sensitivity = vad_ref.get_parameter(aic::VadParameter::Sensitivity);
+    std::cout << "VAD speech hold duration: " << speech_hold_duration << "\n";
     std::cout << "VAD sensitivity: " << sensitivity << "\n";
 
-    // Test all available parameters
-    err = model->set_parameter(aic::EnhancementParameter::EnhancementLevel, 0.8f);
+    err = ctx_ref.set_parameter(aic::ProcessorParameter::EnhancementLevel, 0.8f);
     if (err != aic::ErrorCode::Success)
     {
         std::cerr << "Failed to set enhancement level\n";
         return 1;
     }
 
-    err = model->set_parameter(aic::EnhancementParameter::VoiceGain, 1.2f);
+    err = ctx_ref.set_parameter(aic::ProcessorParameter::VoiceGain, 1.2f);
     if (err != aic::ErrorCode::Success)
     {
         std::cerr << "Failed to set voice gain\n";
         return 1;
     }
 
-    // Test both interleaved and planar processing
-    std::vector<float> buffer(num_frames * num_chans, 0.1f);
+    std::vector<float> interleaved_buffer(config.num_frames * config.num_channels, 0.1f);
 
-    err = model->process_interleaved(buffer.data(), num_chans, num_frames);
+    err = processor_ref.process_interleaved(interleaved_buffer.data(), config.num_channels,
+                                            config.num_frames);
     if (err != aic::ErrorCode::Success)
     {
         std::cerr << "Interleaved processing failed\n";
         return 1;
     }
 
-    // Test planar processing
-    std::vector<float*> channel_ptrs(num_chans);
-    for (uint16_t i = 0; i < num_chans; ++i)
+    std::vector<std::vector<float> > planar_buffers(config.num_channels,
+                                                     std::vector<float>(config.num_frames, 0.1f));
+    std::vector<float*> channel_ptrs(config.num_channels);
+    for (uint16_t i = 0; i < config.num_channels; ++i)
     {
-        channel_ptrs[i] = buffer.data() + (i * num_frames);
+        channel_ptrs[i] = planar_buffers[i].data();
     }
 
-    err = model->process_planar(channel_ptrs.data(), num_chans, num_frames);
+    err = processor_ref.process_planar(channel_ptrs.data(), config.num_channels, config.num_frames);
     if (err != aic::ErrorCode::Success)
     {
         std::cerr << "Planar processing failed\n";
         return 1;
     }
 
-    // Check if speech is detected after processing
-    bool speech_detected = vad->is_speech_detected();
-    if (vad_err != aic::ErrorCode::Success)
+    std::vector<float> sequential_buffer(config.num_frames * config.num_channels, 0.1f);
+    err = processor_ref.process_sequential(sequential_buffer.data(), config.num_channels,
+                                           config.num_frames);
+    if (err != aic::ErrorCode::Success)
     {
-        std::cerr << "Failed to check speech detection\n";
+        std::cerr << "Sequential processing failed\n";
         return 1;
     }
+
+    bool speech_detected = vad_ref.is_speech_detected();
     std::cout << "Speech detected: " << (speech_detected ? "yes" : "no") << "\n";
 
-    // Get all parameter values to verify they were set correctly
-    float enhancement_level = model->get_parameter(aic::EnhancementParameter::EnhancementLevel);
-    float voice_gain        = model->get_parameter(aic::EnhancementParameter::VoiceGain);
+    float enhancement_level = ctx_ref.get_parameter(aic::ProcessorParameter::EnhancementLevel);
+    float voice_gain        = ctx_ref.get_parameter(aic::ProcessorParameter::VoiceGain);
 
     std::cout << "Enhancement level: " << enhancement_level << "\n";
     std::cout << "Voice gain: " << voice_gain << "\n";
 
-    model->reset();
+    err = ctx_ref.reset();
+    if (err != aic::ErrorCode::Success)
+    {
+        std::cerr << "Reset failed\n";
+        return 1;
+    }
 
-    std::cout << "ai-coustics SDK version: " << aic::AicModel::get_sdk_version() << "\n";
     return 0;
 }

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    aic::Model model = std::move(model_result.value);
+    aic::Model model = model_result.take();
     aic::Model& model_ref = model;
     auto config = aic::ProcessorConfig::optimal(model_ref).with_num_channels(1);
 
@@ -61,7 +61,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    aic::Processor processor = std::move(processor_result.value);
+    aic::Processor processor = processor_result.take();
     aic::Processor& processor_ref = processor;
     err = processor_ref.initialize(config.sample_rate, config.num_channels, config.num_frames,
                                    config.allow_variable_frames);
@@ -78,7 +78,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    aic::ProcessorContext ctx = std::move(ctx_result.value);
+    aic::ProcessorContext ctx = ctx_result.take();
     aic::ProcessorContext& ctx_ref = ctx;
     size_t output_delay = ctx_ref.get_output_delay();
     std::cout << "Output delay: " << output_delay << " samples\n";
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    aic::VadContext vad = std::move(vad_result.value);
+    aic::VadContext vad = vad_result.take();
     aic::VadContext& vad_ref = vad;
     err = vad_ref.set_parameter(aic::VadParameter::SpeechHoldDuration, 0.1f);
     if (err != aic::ErrorCode::Success)

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -40,11 +40,11 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto model = model_result.take();
+    auto model  = model_result.take();
     auto config = aic::ProcessorConfig::optimal(model).with_num_channels(1);
 
     auto processor_result = aic::Processor::create(model, license_key);
-    err                                          = processor_result.error;
+    err                   = processor_result.error;
 
     if (!processor_result.ok())
     {
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto ctx = ctx_result.take();
+    auto ctx          = ctx_result.take();
     auto output_delay = ctx.get_output_delay();
     std::cout << "Output delay: " << output_delay << " samples\n";
 
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
     }
 
     auto vad = vad_result.take();
-    err = vad.set_parameter(aic::VadParameter::SpeechHoldDuration, 0.1f);
+    err      = vad.set_parameter(aic::VadParameter::SpeechHoldDuration, 0.1f);
     if (err != aic::ErrorCode::Success)
     {
         std::cerr << "Failed to set VAD speech hold duration\n";
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
     }
 
     auto speech_hold_duration = vad.get_parameter(aic::VadParameter::SpeechHoldDuration);
-    auto sensitivity = vad.get_parameter(aic::VadParameter::Sensitivity);
+    auto sensitivity          = vad.get_parameter(aic::VadParameter::Sensitivity);
     std::cout << "VAD speech hold duration: " << speech_hold_duration << "\n";
     std::cout << "VAD sensitivity: " << sensitivity << "\n";
 
@@ -116,16 +116,15 @@ int main(int argc, char** argv)
     auto interleaved_buffer = std::vector<float>(config.num_frames * config.num_channels, 0.1f);
 
     err = processor.process_interleaved(interleaved_buffer.data(), config.num_channels,
-                                         config.num_frames);
+                                        config.num_frames);
     if (err != aic::ErrorCode::Success)
     {
         std::cerr << "Interleaved processing failed\n";
         return 1;
     }
 
-    auto planar_buffers =
-        std::vector<std::vector<float> >(config.num_channels,
-                                         std::vector<float>(config.num_frames, 0.1f));
+    auto planar_buffers = std::vector<std::vector<float>>(
+        config.num_channels, std::vector<float>(config.num_frames, 0.1f));
     auto channel_ptrs = std::vector<float*>(config.num_channels);
     for (uint16_t i = 0; i < config.num_channels; ++i)
     {
@@ -141,7 +140,7 @@ int main(int argc, char** argv)
 
     auto sequential_buffer = std::vector<float>(config.num_frames * config.num_channels, 0.1f);
     err = processor.process_sequential(sequential_buffer.data(), config.num_channels,
-                                        config.num_frames);
+                                       config.num_frames);
     if (err != aic::ErrorCode::Success)
     {
         std::cerr << "Sequential processing failed\n";

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -3,7 +3,6 @@
 #include <cstdlib>
 #include <iostream>
 #include <string>
-#include <utility>
 #include <vector>
 
 int main(int argc, char** argv)

--- a/include/aic.hpp
+++ b/include/aic.hpp
@@ -90,34 +90,6 @@ enum class VadParameter : int
 };
 
 // ---------------------------
-// Configuration
-// ---------------------------
-
-struct ProcessorConfig
-{
-    uint32_t sample_rate           = 0;
-    uint16_t num_channels          = 1;
-    size_t   num_frames            = 0;
-    bool     allow_variable_frames = false;
-
-    static ProcessorConfig optimal(const class Model& model);
-
-    ProcessorConfig with_num_channels(uint16_t channels) const
-    {
-        ProcessorConfig copy = *this;
-        copy.num_channels    = channels;
-        return copy;
-    }
-
-    ProcessorConfig with_allow_variable_frames(bool allow) const
-    {
-        ProcessorConfig copy       = *this;
-        copy.allow_variable_frames = allow;
-        return copy;
-    }
-};
-
-// ---------------------------
 // Model wrapper
 // ---------------------------
 
@@ -216,7 +188,42 @@ class Model
     Model() : model_(nullptr) {}
     // Wraps an existing SDK model handle; this instance becomes responsible for destroying it.
     explicit Model(::AicModel* model) : model_(model) {}
+};
 
+// ---------------------------
+// Configuration
+// ---------------------------
+
+struct ProcessorConfig
+{
+    uint32_t sample_rate           = 0;
+    uint16_t num_channels          = 1;
+    size_t   num_frames            = 0;
+    bool     allow_variable_frames = false;
+
+    static ProcessorConfig optimal(const Model& model)
+    {
+        ProcessorConfig config;
+        config.sample_rate           = model.get_optimal_sample_rate();
+        config.num_frames            = model.get_optimal_num_frames(config.sample_rate);
+        config.num_channels          = 1;
+        config.allow_variable_frames = false;
+        return config;
+    }
+
+    ProcessorConfig with_num_channels(uint16_t channels) const
+    {
+        ProcessorConfig copy = *this;
+        copy.num_channels    = channels;
+        return copy;
+    }
+
+    ProcessorConfig with_allow_variable_frames(bool allow) const
+    {
+        ProcessorConfig copy       = *this;
+        copy.allow_variable_frames = allow;
+        return copy;
+    }
 };
 
 // ---------------------------
@@ -539,20 +546,6 @@ inline std::string get_sdk_version()
 inline uint32_t get_compatible_model_version()
 {
     return ::aic_get_compatible_model_version();
-}
-
-// ---------------------------
-// ProcessorConfig helpers
-// ---------------------------
-
-inline ProcessorConfig ProcessorConfig::optimal(const Model& model)
-{
-    ProcessorConfig config;
-    config.sample_rate           = model.get_optimal_sample_rate();
-    config.num_frames            = model.get_optimal_num_frames(config.sample_rate);
-    config.num_channels          = 1;
-    config.allow_variable_frames = false;
-    return config;
 }
 
 } // namespace aic

--- a/include/aic.hpp
+++ b/include/aic.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <cassert>
-#include <memory>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <utility>
 
-// Use the new C header name from your snippet.
 #include "aic.h"
 
 namespace aic
@@ -20,78 +20,62 @@ enum class ErrorCode : int
     NullPointer = AIC_ERROR_CODE_NULL_POINTER,
     /// Parameter value is outside the acceptable range. Check documentation for valid values.
     ParameterOutOfRange = AIC_ERROR_CODE_PARAMETER_OUT_OF_RANGE,
-    /// Model must be initialized before calling this operation. Call `aic_model_initialize` first.
+    /// Processor must be initialized before calling this operation. Call `aic_processor_initialize` first.
     ModelNotInitialized = AIC_ERROR_CODE_MODEL_NOT_INITIALIZED,
     /// Audio configuration (samplerate, num_channels, num_frames) is not supported by the model.
     AudioConfigUnsupported = AIC_ERROR_CODE_AUDIO_CONFIG_UNSUPPORTED,
     /// Audio buffer configuration differs from the one provided during initialization.
     AudioConfigMismatch = AIC_ERROR_CODE_AUDIO_CONFIG_MISMATCH,
-    /// The requested parameter is read-only for this model type and cannot be modified.
-    ParameterFixed = AIC_ERROR_CODE_PARAMETER_FIXED,
     /// SDK key was not authorized or process failed to report usage. Check if you have internet
     /// connection.
     EnhancementNotAllowed = AIC_ERROR_CODE_ENHANCEMENT_NOT_ALLOWED,
     /// Internal error occurred. Contact support.
     InternalError = AIC_ERROR_CODE_INTERNAL_ERROR,
+    /// The requested parameter is read-only for this model type and cannot be modified.
+    ParameterFixed = AIC_ERROR_CODE_PARAMETER_FIXED,
     /// License key format is invalid or corrupted. Verify the key was copied correctly.
     LicenseFormatInvalid = AIC_ERROR_CODE_LICENSE_FORMAT_INVALID,
     /// License version is not compatible with the SDK version. Update SDK or contact support.
     LicenseVersionUnsupported = AIC_ERROR_CODE_LICENSE_VERSION_UNSUPPORTED,
     /// License key has expired
     LicenseExpired = AIC_ERROR_CODE_LICENSE_EXPIRED,
+    /// The model file is invalid or corrupted. Verify the file is correct.
+    ModelInvalid = AIC_ERROR_CODE_MODEL_INVALID,
+    /// The model file version is not compatible with this SDK version.
+    ModelVersionUnsupported = AIC_ERROR_CODE_MODEL_VERSION_UNSUPPORTED,
+    /// The path to the model file is invalid.
+    ModelFilePathInvalid = AIC_ERROR_CODE_MODEL_FILE_PATH_INVALID,
+    /// File system error when accessing the model file.
+    FileSystemError = AIC_ERROR_CODE_FILE_SYSTEM_ERROR,
+    /// Model data is not aligned to 64 bytes.
+    ModelDataUnaligned = AIC_ERROR_CODE_MODEL_DATA_UNALIGNED,
 };
 
-/// Available model types for audio enhancement
-enum class ModelType : int
+template <typename T>
+struct Result
 {
-    /// Native: 48 kHz, 480 frames, 30 ms latency
-    Quail_L48 = AIC_MODEL_TYPE_QUAIL_L48,
-    /// Native: 16 kHz, 160 frames, 30 ms latency
-    Quail_L16 = AIC_MODEL_TYPE_QUAIL_L16,
-    /// Native: 8 kHz, 80 frames, 30 ms latency
-    Quail_L8 = AIC_MODEL_TYPE_QUAIL_L8,
-    /// Native: 48 kHz, 480 frames, 30 ms latency
-    Quail_S48 = AIC_MODEL_TYPE_QUAIL_S48,
-    /// Native: 16 kHz, 160 frames, 30 ms latency
-    Quail_S16 = AIC_MODEL_TYPE_QUAIL_S16,
-    /// Native: 8 kHz, 80 frames, 30 ms latency
-    Quail_S8 = AIC_MODEL_TYPE_QUAIL_S8,
-    /// Native: 48 kHz, 480 frames, 10 ms latency
-    Quail_XS = AIC_MODEL_TYPE_QUAIL_XS,
-    /// Native: 48 kHz, 480 frames, 10 ms latency
-    Quail_XXS = AIC_MODEL_TYPE_QUAIL_XXS,
-    /// Special model optimized for human-to-machine interaction (e.g., voice agents, speech-to-text)
-    /// designed specifically to improve STT accuracy across unpredictable, diverse and challenging environments.
-    /// Native: 16 kHz, 160 frames, 30 ms latency
-    Quail_STT_L16 = AIC_MODEL_TYPE_QUAIL_STT_L16,
-    /// Special model optimized for human-to-machine interaction (e.g., voice agents, speech-to-text)
-    /// designed specifically to improve STT accuracy across unpredictable, diverse and challenging environments.
-    /// Native: 8 kHz, 80 frames, 30 ms latency
-    Quail_STT_L8 = AIC_MODEL_TYPE_QUAIL_STT_L8,
-    /// Special model optimized for human-to-machine interaction (e.g., voice agents, speech-to-text)
-    /// designed specifically to improve STT accuracy across unpredictable, diverse and challenging environments.
-    /// Native: 16 kHz, 160 frames, 30 ms latency
-    Quail_STT_S16 = AIC_MODEL_TYPE_QUAIL_STT_S16,
-    /// Special model optimized for human-to-machine interaction (e.g., voice agents, speech-to-text)
-    /// designed specifically to improve STT accuracy across unpredictable, diverse and challenging environments.
-    /// Native: 8 kHz, 80 frames, 30 ms latency
-    Quail_STT_S8 = AIC_MODEL_TYPE_QUAIL_STT_S8,
-    /// Special model optimized for human-to-machine interaction (e.g., voice agents, speech-to-text)
-    /// purpose-built to isolate and elevate the foreground speaker while suppressing both
-    /// interfering speech and background noise.
-    /// Native: 16 kHz, 160 frames, 30 ms latency
-    Quail_VF_STT_L16 = AIC_MODEL_TYPE_QUAIL_VF_STT_L16,
+    T         value;
+    ErrorCode error;
+
+    // Default-constructs the value and sets a non-success error as a safe sentinel.
+    Result() : value(), error(ErrorCode::InternalError) {}
+    // Constructs a Result by copying the value and storing the error code.
+    Result(const T& v, ErrorCode e) : value(v), error(e) {}
+    // Constructs a Result by moving the value and storing the error code.
+    Result(T&& v, ErrorCode e) : value(std::move(v)), error(e) {}
+
+    bool ok() const { return error == ErrorCode::Success; }
 };
 
 /// Configurable parameters for audio enhancement
-enum class EnhancementParameter : int
+enum class ProcessorParameter : int
 {
     /// Bypass keeping processing delay (0.0/1.0): 0.0=disabled, 1.0=enabled
-    Bypass = AIC_ENHANCEMENT_PARAMETER_BYPASS,
+    Bypass = AIC_PROCESSOR_PARAMETER_BYPASS,
     /// Enhancement intensity (0.0-1.0): 0.0=bypass, 1.0=full enhancement
-    EnhancementLevel = AIC_ENHANCEMENT_PARAMETER_ENHANCEMENT_LEVEL,
+    EnhancementLevel = AIC_PROCESSOR_PARAMETER_ENHANCEMENT_LEVEL,
     /// Voice gain multiplier (0.1-4.0): linear amplitude multiplier
-    VoiceGain = AIC_ENHANCEMENT_PARAMETER_VOICE_GAIN,
+    VoiceGain = AIC_PROCESSOR_PARAMETER_VOICE_GAIN,
 };
 
 /// Configurable parameters for voice activity detection (VAD)
@@ -113,14 +97,12 @@ inline constexpr ::AicErrorCode to_c(ErrorCode e)
 {
     return static_cast<::AicErrorCode>(static_cast<int>(e));
 }
-inline constexpr ::AicModelType to_c(ModelType m)
+
+inline constexpr ::AicProcessorParameter to_c(ProcessorParameter p)
 {
-    return static_cast<::AicModelType>(static_cast<int>(m));
+    return static_cast<::AicProcessorParameter>(static_cast<int>(p));
 }
-inline constexpr ::AicEnhancementParameter to_c(EnhancementParameter p)
-{
-    return static_cast<::AicEnhancementParameter>(static_cast<int>(p));
-}
+
 inline constexpr ::AicVadParameter to_c(VadParameter p)
 {
     return static_cast<::AicVadParameter>(static_cast<int>(p));
@@ -132,195 +114,206 @@ inline constexpr ErrorCode to_cpp(::AicErrorCode e)
 }
 
 // ---------------------------
-// C++ wrapper class
+// Configuration
 // ---------------------------
 
-/**
- * C++ wrapper for the ai-coustics audio enhancement SDK.
- *
- * Provides a modern C++ interface around the C API with RAII resource management.
- * Multiple models can be created to process different audio streams simultaneously
- * or to switch between different enhancement algorithms during runtime.
- *
- * - No exceptions
- * - No convenience functions
- * - Thin RAII around the C API
- */
-class AicModel
+struct ProcessorConfig
+{
+    uint32_t sample_rate           = 0;
+    uint16_t num_channels          = 1;
+    size_t   num_frames            = 0;
+    bool     allow_variable_frames = false;
+
+    static ProcessorConfig optimal(const class Model& model);
+
+    ProcessorConfig with_num_channels(uint16_t channels) const
+    {
+        ProcessorConfig copy = *this;
+        copy.num_channels    = channels;
+        return copy;
+    }
+
+    ProcessorConfig with_allow_variable_frames(bool allow) const
+    {
+        ProcessorConfig copy       = *this;
+        copy.allow_variable_frames = allow;
+        return copy;
+    }
+};
+
+// ---------------------------
+// Model wrapper
+// ---------------------------
+
+class Model
 {
   private:
-    std::unique_ptr<::AicModel, void (*)(::AicModel*)> model_;
+    ::AicModel* model_;
 
   public:
-    // Constructor for internal use by create() method
-    explicit AicModel(::AicModel* model) : model_(model, aic_model_destroy) {}
-
-    // Internal accessor for C API interop (used by AicVad)
-    ::AicModel* get_c_model() const { return model_.get(); }
-
-    /**
-     * Creates a new audio enhancement model instance.
-     *
-     * Multiple models can be created to process different audio streams simultaneously
-     * or to switch between different enhancement algorithms during runtime.
-     *
-     * @param model_type The enhancement algorithm variant to use
-     * @param license_key Your license key as a null-terminated string
-     * @return Pair containing Model pointer and error code.
-     *         If successful, the pointer is valid and error is ErrorCode::Success.
-     *         If failed, the pointer is null and error indicates the reason:
-     *         - ErrorCode::LicenseInvalid: License key format is incorrect
-     *         - ErrorCode::LicenseVersionUnsupported: not compatible with SDK version
-     *         - ErrorCode::LicenseExpired: License key has expired
-     */
-    static std::pair<std::unique_ptr<AicModel>, ErrorCode> create(ModelType model_type, const std::string& license_key);
-
-    // Disable copy constructor and assignment
-    AicModel(const AicModel&)            = delete;
-    AicModel& operator=(const AicModel&) = delete;
-
-    /**
-     * Configures the model for a specific audio format.
-     *
-     * This function must be called before processing any audio.
-     * For the lowest delay, use the sample rate and frame size returned by
-     * get_optimal_sample_rate() and get_optimal_num_frames().
-     *
-     * @warning Do not call from audio processing threads as this allocates memory.
-     *
-     * @note All channels are mixed to mono for processing. To process channels
-     *       independently, create separate model instances.
-     *
-     * @param sample_rate Audio sample rate in Hz (8000 - 192000)
-     * @param num_channels Number of audio channels (1 for mono, 2 for stereo, etc.)
-     * @param num_frames Number of samples per channel in each process call
-     * @param allow_variable_frames Process can be called with variable number of frames for the
-     * cost of higher latency
-     * @return ErrorCode::Success if configuration accepted,
-     *         ErrorCode::AudioConfigUnsupported if configuration is not supported
-     */
-    ErrorCode initialize(uint32_t sample_rate, uint16_t num_channels, size_t num_frames,
-                         bool allow_variable_frames)
+    // Releases the underlying SDK model handle if one is owned.
+    ~Model()
     {
-        ::AicErrorCode rc = aic_model_initialize(model_.get(), sample_rate, num_channels,
-                                                 num_frames, allow_variable_frames);
-        return to_cpp(rc);
+        if (model_)
+        {
+            aic_model_destroy(model_);
+        }
     }
+
+    // Transfers ownership of the model handle from another Model (the source becomes empty).
+    Model(Model&& other) noexcept : model_(other.model_)
+    {
+        other.model_ = nullptr;
+    }
+
+    // Replaces the currently owned handle with another Model's handle, cleaning up the old one.
+    Model& operator=(Model&& other) noexcept
+    {
+        if (this != &other)
+        {
+            if (model_)
+            {
+                aic_model_destroy(model_);
+            }
+            model_       = other.model_;
+            other.model_ = nullptr;
+        }
+        return *this;
+    }
+
+    // Copying is disabled because this wrapper has unique ownership of the handle.
+    Model(const Model&)            = delete;
+    // Copy assignment is disabled for the same reason as the copy constructor.
+    Model& operator=(const Model&) = delete;
+
+    // Internal accessor for C API interop
+    ::AicModel* get_c_model() const { return model_; }
+
+    bool is_valid() const { return model_ != nullptr; }
+
+    /**
+     * Creates a new model instance from a file path.
+     */
+    static Result<Model> create_from_file(const std::string& file_path);
+
+    /**
+     * Creates a new model instance from a memory buffer.
+     *
+     * The buffer must remain valid and 64-byte aligned for the lifetime of the model.
+     */
+    static Result<Model> create_from_buffer(const uint8_t* buffer, size_t buffer_len);
+
+    /**
+     * Returns the model identifier string.
+     */
+    std::string get_id() const
+    {
+        const char* id = aic_model_get_id(model_);
+        return id ? std::string(id) : std::string();
+    }
+
+    /**
+     * Retrieves the native sample rate of the selected model.
+     */
+    uint32_t get_optimal_sample_rate() const
+    {
+        uint32_t       sample_rate = 0;
+        ::AicErrorCode rc          = aic_model_get_optimal_sample_rate(model_, &sample_rate);
+        assert(rc == AIC_ERROR_CODE_SUCCESS);
+        (void) rc;
+        return sample_rate;
+    }
+
+    /**
+     * Retrieves the optimal number of frames for the selected model and sample rate.
+     */
+    size_t get_optimal_num_frames(uint32_t sample_rate) const
+    {
+        size_t         num_frames = 0;
+        ::AicErrorCode rc = aic_model_get_optimal_num_frames(model_, sample_rate, &num_frames);
+        assert(rc == AIC_ERROR_CODE_SUCCESS);
+        (void) rc;
+        return num_frames;
+    }
+
+  private:
+    // Creates an empty Model wrapper for internal use when creation fails.
+    Model() : model_(nullptr) {}
+    // Wraps an existing SDK model handle; this instance becomes responsible for destroying it.
+    explicit Model(::AicModel* model) : model_(model) {}
+
+};
+
+// ---------------------------
+// Processor context wrapper
+// ---------------------------
+
+class ProcessorContext
+{
+  private:
+    ::AicProcessorContext* context_;
+
+  public:
+    // Releases the underlying SDK processor context handle if one is owned.
+    ~ProcessorContext()
+    {
+        if (context_)
+        {
+            aic_processor_context_destroy(context_);
+        }
+    }
+
+    // Transfers ownership of the context handle from another ProcessorContext (the source becomes empty).
+    ProcessorContext(ProcessorContext&& other) noexcept : context_(other.context_)
+    {
+        other.context_ = nullptr;
+    }
+
+    // Replaces the currently owned handle with another context handle, cleaning up the old one.
+    ProcessorContext& operator=(ProcessorContext&& other) noexcept
+    {
+        if (this != &other)
+        {
+            if (context_)
+            {
+                aic_processor_context_destroy(context_);
+            }
+            context_       = other.context_;
+            other.context_ = nullptr;
+        }
+        return *this;
+    }
+
+    // Copying is disabled because this wrapper has unique ownership of the handle.
+    ProcessorContext(const ProcessorContext&)            = delete;
+    // Copy assignment is disabled for the same reason as the copy constructor.
+    ProcessorContext& operator=(const ProcessorContext&) = delete;
 
     /**
      * Clears all internal state and buffers.
-     *
-     * Call this when the audio stream is interrupted or when seeking
-     * to prevent artifacts from previous audio content.
-     * The model stays initialized to the configured settings.
-     *
-     * @note Real-time safe. Can be called from audio processing threads.
-     *
-     * Wrapper keeps the previous behavior: void + assert on success.
      */
-    void reset()
+    ErrorCode reset() const
     {
-        ::AicErrorCode rc = aic_model_reset(model_.get());
-        (void) rc;
-        assert(rc == AIC_ERROR_CODE_SUCCESS);
-    }
-
-    /**
-     * Processes audio with separate buffers for each channel (planar layout).
-     *
-     * Enhances speech in the provided audio buffers in-place.
-     * The planar function allows a maximum of 16 channels.
-     *
-     * @param audio Array of channel buffer pointers. Must not be null.
-     * @param num_channels Number of channels (must match initialization)
-     * @param num_frames Number of samples per channel (must match initialization)
-     * @return ErrorCode::Success if audio processed successfully,
-     *         ErrorCode::NotInitialized if model has not been initialized,
-     *         ErrorCode::AudioConfigMismatch if channel or frame count mismatch
-     *         ErrorCode::EnhancementNotAllowed if backend blocks or could not be contacted
-     */
-    ErrorCode process_planar(float* const* audio, uint16_t num_channels, size_t num_frames)
-    {
-        ::AicErrorCode rc = aic_model_process_planar(model_.get(), audio, num_channels, num_frames);
+        ::AicErrorCode rc = aic_processor_context_reset(context_);
         return to_cpp(rc);
     }
 
     /**
-     * Processes audio with interleaved channel data.
-     *
-     * Enhances speech in the provided audio buffer in-place.
-     *
-     * @param audio Interleaved audio buffer. Must not be null and exactly of size
-     *              num_channels * num_frames.
-     * @param num_channels Number of channels (must match initialization)
-     * @param num_frames Number of frames (must match initialization)
-     * @return ErrorCode::Success if audio processed successfully,
-     *         ErrorCode::NotInitialized if model has not been initialized,
-     *         ErrorCode::AudioConfigMismatch if channel or frame count mismatch
-     *         ErrorCode::EnhancementNotAllowed if backend blocks or could not be contacted
+     * Modifies a processor parameter.
      */
-    ErrorCode process_interleaved(float* audio, uint16_t num_channels, size_t num_frames)
+    ErrorCode set_parameter(ProcessorParameter parameter, float value) const
     {
-        ::AicErrorCode rc =
-            aic_model_process_interleaved(model_.get(), audio, num_channels, num_frames);
-        return to_cpp(rc);
-    }
-
-    /**
-     * Processes audio with sequential channel data (non-interleaved).
-     *
-     * Enhances speech in the provided audio buffer in-place.
-     * The buffer must contain all channels sequentially (e.g. ch0...ch0, ch1...ch1).
-     *
-     * @param audio Audio buffer containing sequential channel data. Must not be null and of size num_channels * num_frames.
-     * @param num_channels Number of channels (must match initialization)
-     * @param num_frames Number of frames (must match initialization)
-     * @return ErrorCode::Success if audio processed successfully,
-     *         ErrorCode::NotInitialized if model has not been initialized,
-     *         ErrorCode::AudioConfigMismatch if channel or frame count mismatch
-     *         ErrorCode::EnhancementNotAllowed if backend blocks or could not be contacted
-     */
-    ErrorCode process_sequential(float* audio, uint16_t num_channels, size_t num_frames)
-    {
-        ::AicErrorCode rc = aic_model_process_sequential(model_.get(), audio, num_channels, num_frames);
-        return to_cpp(rc);
-    }
-
-    /**
-     * Modifies a model parameter.
-     *
-     * All parameters can be changed during audio processing.
-     * This function can be called from any thread.
-     *
-     * Parameter ranges:
-     * - EnhancementLevel: 0.0 to 1.0 (0.0=bypass, 1.0=full enhancement)
-     * - VoiceGain: 0.1 to 4.0 (linear amplitude multiplier, 1.0=no change)
-     * - NoiseGateEnable: 0.0 or 1.0 (0.0=disabled, 1.0=enabled)
-     *
-     * @param parameter Parameter to modify
-     * @param value New parameter value (see ranges above)
-     * @return ErrorCode::Success if parameter updated successfully,
-     *         ErrorCode::ParameterOutOfRange if value outside valid range
-     */
-    ErrorCode set_parameter(EnhancementParameter parameter, float value)
-    {
-        ::AicErrorCode rc = aic_model_set_parameter(model_.get(), to_c(parameter), value);
+        ::AicErrorCode rc = aic_processor_context_set_parameter(context_, to_c(parameter), value);
         return to_cpp(rc);
     }
 
     /**
      * Retrieves the current value of a parameter.
-     *
-     * This function can be called from any thread.
-     * This method keeps the old behavior: assert on success, return value.
-     *
-     * @param parameter Parameter to query
-     * @return Current parameter value
      */
-    float get_parameter(EnhancementParameter parameter) const
+    float get_parameter(ProcessorParameter parameter) const
     {
         float          value = 0.0f;
-        ::AicErrorCode rc    = aic_model_get_parameter(model_.get(), to_c(parameter), &value);
+        ::AicErrorCode rc = aic_processor_context_get_parameter(context_, to_c(parameter), &value);
         assert(rc == AIC_ERROR_CODE_SUCCESS);
         (void) rc;
         return value;
@@ -328,166 +321,79 @@ class AicModel
 
     /**
      * Returns the total output delay in samples for the current audio configuration.
-     *
-     * This function provides the complete end-to-end latency introduced by the model,
-     * which includes both algorithmic processing delay and any buffering overhead.
-     * Use this value to synchronize enhanced audio with other streams or to implement
-     * delay compensation in your application.
-     *
-     * Delay behavior:
-     * - Before initialization: Returns the base processing delay using the model's
-     *   optimal frame size at its native sample rate
-     * - After initialization: Returns the actual delay for your specific configuration,
-     *   including any additional buffering introduced by non-optimal frame sizes
-     *
-     * The delay value is always expressed in samples at the sample rate you configured
-     * during initialize(). To convert to time units:
-     * delay_ms = (delay_samples * 1000) / sample_rate
-     *
-     * @note Using frame sizes different from the optimal value returned by
-     *       get_optimal_num_frames() will increase the delay beyond the model's base latency.
-     *
-     * Keeps previous behavior (assert on success).
-     *
-     * @return Processing latency in samples
      */
     size_t get_output_delay() const
     {
         size_t         latency = 0;
-        ::AicErrorCode rc      = aic_get_output_delay(model_.get(), &latency);
+        ::AicErrorCode rc      = aic_processor_context_get_output_delay(context_, &latency);
         assert(rc == AIC_ERROR_CODE_SUCCESS);
         (void) rc;
         return latency;
     }
 
-    /**
-     * Retrieves the native sample rate of the selected model.
-     *
-     * Each model is optimized for a specific sample rate, which determines the frequency
-     * range of the enhanced audio output. While you can process audio at any sample rate,
-     * understanding the model's native rate helps predict the enhancement quality.
-     *
-     * How sample rate affects enhancement:
-     * - Models trained at lower sample rates (e.g., 8 kHz) can only enhance frequencies
-     *   up to their Nyquist limit (4 kHz for 8 kHz models)
-     * - When processing higher sample rate input (e.g., 48 kHz) with a lower-rate model,
-     *   only the lower frequency components will be enhanced
-     *
-     * Enhancement blending:
-     * When enhancement strength is set below 1.0, the enhanced signal is blended with
-     * the original, maintaining the full frequency spectrum of your input while adding
-     * the model's noise reduction capabilities to the lower frequencies.
-     *
-     * @note For maximum enhancement quality across the full frequency spectrum,
-     *       match your input sample rate to the model's native rate when possible.
-     *
-     * Keeps previous behavior (assert on success).
-     *
-     * @return Optimal sample rate in Hz
-     */
-    uint32_t get_optimal_sample_rate() const
-    {
-        uint32_t       sample_rate = 0;
-        ::AicErrorCode rc          = aic_get_optimal_sample_rate(model_.get(), &sample_rate);
-        assert(rc == AIC_ERROR_CODE_SUCCESS);
-        (void) rc;
-        return sample_rate;
-    }
+  private:
+    // Allows Processor to construct ProcessorContext instances from raw handles.
+    friend class Processor;
 
-    /**
-     * Retrieves the native number of frames for the selected model and sample rate.
-     *
-     * Using the optimal number of frames minimizes latency by avoiding internal buffering.
-     * When you use a different frame count than the optimal value, the model will
-     * introduce additional buffering latency on top of its base processing delay.
-     *
-     * The optimal frame count adjusts dynamically based on the sample rate used during
-     * initialize(). Each time you call initialize() with a different sample rate,
-     * the optimal number of frames will update accordingly. Before initialization is called,
-     * this function returns the optimal frame count for the model's native sample rate.
-     *
-     * Each model operates on a fixed time window duration, so the required number of frames
-     * varies with sample rate. For example, a model designed for 10 ms processing windows
-     * requires 480 frames at 48 kHz, but only 160 frames at 16 kHz to capture the same
-     * duration of audio.
-     *
-     * @param sample_rate The sample rate you want to know the optimal number of frames for
-     * @return Optimal number of frames
-     */
-    size_t get_optimal_num_frames(uint32_t sample_rate) const
-    {
-        size_t         num_frames = 0;
-        ::AicErrorCode rc = aic_get_optimal_num_frames(model_.get(), sample_rate, &num_frames);
-        assert(rc == AIC_ERROR_CODE_SUCCESS);
-        (void) rc;
-        return num_frames;
-    }
+    // Creates an empty context wrapper for internal use when creation fails.
+    ProcessorContext() : context_(nullptr) {}
+    // Wraps an existing SDK processor context handle; this instance becomes responsible for destroying it.
+    explicit ProcessorContext(::AicProcessorContext* context) : context_(context) {}
 
-    /**
-     * Returns the version of the SDK.
-     *
-     * @return A string containing the version (e.g., "1.2.3")
-     */
-    static std::string get_sdk_version()
-    {
-        const char* v = ::aic_get_sdk_version();
-        return v ? std::string(v) : std::string();
-    }
 };
 
-/**
- * C++ wrapper for the ai-coustics Voice Activity Detection (VAD).
- *
- * Provides a modern C++ interface around the C VAD API with RAII resource management.
- * The VAD is created from an existing AicModel and detects speech activity in the
- * processed audio stream.
- *
- * - No exceptions
- * - No convenience functions
- * - Thin RAII around the C API
- */
-class AicVad
+// ---------------------------
+// VAD context wrapper
+// ---------------------------
+
+class VadContext
 {
   private:
-    std::unique_ptr<::AicVad, void (*)(::AicVad*)> vad_;
+    ::AicVadContext* context_;
 
   public:
-    // Constructor for internal use by create() method
-    explicit AicVad(::AicVad* vad) : vad_(vad, aic_vad_destroy) {}
+    // Releases the underlying SDK VAD context handle if one is owned.
+    ~VadContext()
+    {
+        if (context_)
+        {
+            aic_vad_context_destroy(context_);
+        }
+    }
 
-    /**
-     * Creates a new Voice Activity Detection (VAD) instance.
-     *
-     * The VAD works automatically using the enhanced audio output of the given model.
-     *
-     * @note If the backing model is destroyed, the VAD instance will stop
-     *       producing new data. It is safe to destroy the model without destroying the VAD.
-     *
-     * @param model The AicModel instance to use as data source for the VAD
-     * @return Pair containing AicVad pointer and error code.
-     *         If successful, the pointer is valid and error is ErrorCode::Success.
-     *         If failed, the pointer is null and error indicates the reason.
-     */
-    static std::pair<std::unique_ptr<AicVad>, ErrorCode> create(AicModel& model);
+    // Transfers ownership of the context handle from another VadContext (the source becomes empty).
+    VadContext(VadContext&& other) noexcept : context_(other.context_)
+    {
+        other.context_ = nullptr;
+    }
 
-    // Disable copy constructor and assignment
-    AicVad(const AicVad&)            = delete;
-    AicVad& operator=(const AicVad&) = delete;
+    // Replaces the currently owned handle with another context handle, cleaning up the old one.
+    VadContext& operator=(VadContext&& other) noexcept
+    {
+        if (this != &other)
+        {
+            if (context_)
+            {
+                aic_vad_context_destroy(context_);
+            }
+            context_       = other.context_;
+            other.context_ = nullptr;
+        }
+        return *this;
+    }
+
+    // Copying is disabled because this wrapper has unique ownership of the handle.
+    VadContext(const VadContext&)            = delete;
+    // Copy assignment is disabled for the same reason as the copy constructor.
+    VadContext& operator=(const VadContext&) = delete;
 
     /**
      * Returns the VAD's speech detection prediction.
-     *
-     * @note The latency of the VAD prediction is equal to the backing model's
-     *       processing latency.
-     * @note If the backing model stops being processed, the VAD will not update
-     *       its speech detection prediction.
-     *
-     * @return The VAD prediction (true if speech detected, false otherwise)
      */
     bool is_speech_detected() const
     {
-        bool value = false;
-        ::AicErrorCode rc = aic_vad_is_speech_detected(vad_.get(), &value);
+        bool           value = false;
+        ::AicErrorCode rc    = aic_vad_context_is_speech_detected(context_, &value);
         assert(rc == AIC_ERROR_CODE_SUCCESS);
         (void) rc;
         return value;
@@ -495,42 +401,175 @@ class AicVad
 
     /**
      * Modifies a VAD parameter.
-     *
-     * All parameters can be changed during audio processing.
-     * This function can be called from any thread.
-     *
-     * Parameter ranges:
-     * - LookbackBufferSize: 1.0 to 20.0 (controls lookback buffer size)
-     * - Sensitivity: 1.0 to 15.0 (controls energy threshold)
-     *
-     * @param parameter Parameter to modify
-     * @param value New parameter value (see ranges above)
-     * @return ErrorCode::Success if parameter updated successfully,
-     *         ErrorCode::ParameterOutOfRange if value outside valid range
      */
-    ErrorCode set_parameter(VadParameter parameter, float value)
+    ErrorCode set_parameter(VadParameter parameter, float value) const
     {
-        ::AicErrorCode rc = aic_vad_set_parameter(vad_.get(), to_c(parameter), value);
+        ::AicErrorCode rc = aic_vad_context_set_parameter(context_, to_c(parameter), value);
         return to_cpp(rc);
     }
 
     /**
      * Retrieves the current value of a VAD parameter.
-     *
-     * This function can be called from any thread.
-     * This method keeps the old behavior: assert on success, return value.
-     *
-     * @param parameter Parameter to query
-     * @return Current parameter value
      */
     float get_parameter(VadParameter parameter) const
     {
         float          value = 0.0f;
-        ::AicErrorCode rc    = aic_vad_get_parameter(vad_.get(), to_c(parameter), &value);
+        ::AicErrorCode rc = aic_vad_context_get_parameter(context_, to_c(parameter), &value);
         assert(rc == AIC_ERROR_CODE_SUCCESS);
         (void) rc;
         return value;
     }
+
+  private:
+    // Allows Processor to construct VadContext instances from raw handles.
+    friend class Processor;
+
+    // Creates an empty VAD context wrapper for internal use when creation fails.
+    VadContext() : context_(nullptr) {}
+    // Wraps an existing SDK VAD context handle; this instance becomes responsible for destroying it.
+    explicit VadContext(::AicVadContext* context) : context_(context) {}
+
 };
+
+// ---------------------------
+// Processor wrapper
+// ---------------------------
+
+class Processor
+{
+  private:
+    ::AicProcessor* processor_;
+
+  public:
+    // Releases the underlying SDK processor handle if one is owned.
+    ~Processor()
+    {
+        if (processor_)
+        {
+            aic_processor_destroy(processor_);
+        }
+    }
+
+    // Transfers ownership of the processor handle from another Processor (the source becomes empty).
+    Processor(Processor&& other) noexcept : processor_(other.processor_)
+    {
+        other.processor_ = nullptr;
+    }
+
+    // Replaces the currently owned handle with another processor handle, cleaning up the old one.
+    Processor& operator=(Processor&& other) noexcept
+    {
+        if (this != &other)
+        {
+            if (processor_)
+            {
+                aic_processor_destroy(processor_);
+            }
+            processor_       = other.processor_;
+            other.processor_ = nullptr;
+        }
+        return *this;
+    }
+
+    // Copying is disabled because this wrapper has unique ownership of the handle.
+    Processor(const Processor&)            = delete;
+    // Copy assignment is disabled for the same reason as the copy constructor.
+    Processor& operator=(const Processor&) = delete;
+
+    /**
+     * Creates a new audio enhancement processor instance.
+     */
+    static Result<Processor> create(const Model& model, const std::string& license_key);
+
+    /**
+     * Configures the processor for a specific audio format.
+     */
+    ErrorCode initialize(uint32_t sample_rate, uint16_t num_channels, size_t num_frames,
+                         bool allow_variable_frames)
+    {
+        ::AicErrorCode rc = aic_processor_initialize(processor_, sample_rate, num_channels,
+                                                     num_frames, allow_variable_frames);
+        return to_cpp(rc);
+    }
+
+    /**
+     * Processes audio with separate buffers for each channel (planar layout).
+     */
+    ErrorCode process_planar(float* const* audio, uint16_t num_channels, size_t num_frames)
+    {
+        ::AicErrorCode rc = aic_processor_process_planar(processor_, audio, num_channels, num_frames);
+        return to_cpp(rc);
+    }
+
+    /**
+     * Processes audio with interleaved channel data.
+     */
+    ErrorCode process_interleaved(float* audio, uint16_t num_channels, size_t num_frames)
+    {
+        ::AicErrorCode rc = aic_processor_process_interleaved(processor_, audio, num_channels, num_frames);
+        return to_cpp(rc);
+    }
+
+    /**
+     * Processes audio with sequential channel data (non-interleaved).
+     */
+    ErrorCode process_sequential(float* audio, uint16_t num_channels, size_t num_frames)
+    {
+        ::AicErrorCode rc = aic_processor_process_sequential(processor_, audio, num_channels, num_frames);
+        return to_cpp(rc);
+    }
+
+    /**
+     * Creates a processor context handle for thread-safe control APIs.
+     */
+    Result<ProcessorContext> create_context() const;
+
+    /**
+     * Creates a VAD context handle for thread-safe control APIs.
+     */
+    Result<VadContext> create_vad_context() const;
+
+  private:
+    // Creates an empty Processor wrapper for internal use when creation fails.
+    Processor() : processor_(nullptr) {}
+    // Wraps an existing SDK processor handle; this instance becomes responsible for destroying it.
+    explicit Processor(::AicProcessor* processor) : processor_(processor) {}
+
+};
+
+// ---------------------------
+// SDK info helpers
+// ---------------------------
+
+/**
+ * Returns the version of the SDK.
+ */
+inline std::string get_sdk_version()
+{
+    const char* v = ::aic_get_sdk_version();
+    return v ? std::string(v) : std::string();
+}
+
+/**
+ * Returns the model version compatible with the SDK.
+ */
+inline uint32_t get_compatible_model_version()
+{
+    return ::aic_get_compatible_model_version();
+}
+
+// ---------------------------
+// ProcessorConfig helpers
+// ---------------------------
+
+inline ProcessorConfig ProcessorConfig::optimal(const Model& model)
+{
+    ProcessorConfig config;
+    config.sample_rate           = model.get_optimal_sample_rate();
+    config.num_frames            = model.get_optimal_num_frames(config.sample_rate);
+    config.num_channels          = 1;
+    config.allow_variable_frames = false;
+    return config;
+}
 
 } // namespace aic

--- a/include/aic.hpp
+++ b/include/aic.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include "aic.h"
+
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <string>
 #include <utility>
-
-#include "aic.h"
 
 namespace aic
 {
@@ -22,7 +22,8 @@ enum class ErrorCode : int
     NullPointer = AIC_ERROR_CODE_NULL_POINTER,
     /// Parameter value is outside the acceptable range. Check documentation for valid values.
     ParameterOutOfRange = AIC_ERROR_CODE_PARAMETER_OUT_OF_RANGE,
-    /// Processor must be initialized before calling this operation. Call Processor::initialize first.
+    /// Processor must be initialized before calling this operation. Call Processor::initialize
+    /// first.
     ModelNotInitialized = AIC_ERROR_CODE_MODEL_NOT_INITIALIZED,
     /// Audio configuration (samplerate, num_channels, num_frames) is not supported by the model.
     AudioConfigUnsupported = AIC_ERROR_CODE_AUDIO_CONFIG_UNSUPPORTED,
@@ -58,15 +59,15 @@ enum class ErrorCode : int
  *
  * @tparam T Value type stored in the result.
  */
-template <typename T>
-struct Result
+template <typename T> struct Result
 {
     /// The returned value (may be default-constructed on failure).
-    T         value;
+    T value;
     /// Error status for the operation.
     ErrorCode error;
 
-    // Default constructor: default-constructs the value and sets a non-success error as a safe sentinel
+    // Default constructor: default-constructs the value and sets a non-success error as a safe
+    // sentinel
     Result() : value(), error(ErrorCode::InternalError) {}
     // Constructor: copies the value and stores the error code
     Result(const T& v, ErrorCode e) : value(v), error(e) {}
@@ -74,9 +75,15 @@ struct Result
     Result(T&& v, ErrorCode e) : value(std::move(v)), error(e) {}
 
     /// Returns true when error == ErrorCode::Success.
-    bool ok() const { return error == ErrorCode::Success; }
+    bool ok() const
+    {
+        return error == ErrorCode::Success;
+    }
     /// Returns the contained value by move (useful for move-only types).
-    T take() { return std::move(value); }
+    T take()
+    {
+        return std::move(value);
+    }
 };
 
 /**
@@ -97,11 +104,13 @@ enum class ProcessorParameter : int
  */
 enum class VadParameter : int
 {
-    /// Controls for how long the VAD continues to detect speech after the audio signal no longer contains speech. (0.0 to 20x model window length in seconds)
+    /// Controls for how long the VAD continues to detect speech after the audio signal no longer
+    /// contains speech. (0.0 to 20x model window length in seconds)
     SpeechHoldDuration = AIC_VAD_PARAMETER_SPEECH_HOLD_DURATION,
     /// Controls the sensitivity (energy threshold) of the VAD. (1.0-15.0)
     Sensitivity = AIC_VAD_PARAMETER_SENSITIVITY,
-    /// Controls for how long speech needs to be present in the audio signal before the VAD considers it speech (0.0 - 1.0 seconds).
+    /// Controls for how long speech needs to be present in the audio signal before the VAD
+    /// considers it speech (0.0 - 1.0 seconds).
     MinimumSpeechDuration = AIC_VAD_PARAMETER_MINIMUM_SPEECH_DURATION,
 };
 
@@ -130,7 +139,8 @@ class Model
         other.model_ = nullptr;
     }
 
-    // Move assignment: replaces the currently owned handle with the source handle and clears the source
+    // Move assignment: replaces the currently owned handle with the source handle and clears the
+    // source
     Model& operator=(Model&& other) noexcept
     {
         if (this != &other)
@@ -145,8 +155,9 @@ class Model
         return *this;
     }
 
-    // Deleted copy constructor: copying is disabled because this wrapper has unique ownership of the handle
-    Model(const Model&)            = delete;
+    // Deleted copy constructor: copying is disabled because this wrapper has unique ownership of
+    // the handle
+    Model(const Model&) = delete;
 
     // Deleted copy assignment: copying is disabled for the same reason as the copy constructor
     Model& operator=(const Model&) = delete;
@@ -162,7 +173,8 @@ class Model
      * @note Processor instances retain a shared reference to the model data.
      *       It is safe to destroy the Model after creating the desired processors.
      *       The memory used by the model is freed after all processors are destroyed.
-     * @warning Not thread-safe. Ensure no other threads are using the model handle or the same file path.
+     * @warning Not thread-safe. Ensure no other threads are using the model handle or the same file
+     * path.
      */
     static Result<Model> create_from_file(const std::string& file_path);
 
@@ -359,13 +371,15 @@ class ProcessorContext
         }
     }
 
-    // Move constructor: the handle from the source ProcessorContext gets moved into the new ProcessorContext
+    // Move constructor: the handle from the source ProcessorContext gets moved into the new
+    // ProcessorContext
     ProcessorContext(ProcessorContext&& other) noexcept : context_(other.context_)
     {
         other.context_ = nullptr;
     }
 
-    // Move assignment: replaces the currently owned handle with the source handle and clears the source
+    // Move assignment: replaces the currently owned handle with the source handle and clears the
+    // source
     ProcessorContext& operator=(ProcessorContext&& other) noexcept
     {
         if (this != &other)
@@ -380,8 +394,9 @@ class ProcessorContext
         return *this;
     }
 
-    // Deleted copy constructor: copying is disabled because this wrapper has unique ownership of the handle
-    ProcessorContext(const ProcessorContext&)            = delete;
+    // Deleted copy constructor: copying is disabled because this wrapper has unique ownership of
+    // the handle
+    ProcessorContext(const ProcessorContext&) = delete;
 
     // Deleted copy assignment: copying is disabled for the same reason as the copy constructor
     ProcessorContext& operator=(const ProcessorContext&) = delete;
@@ -436,7 +451,7 @@ class ProcessorContext
     float get_parameter(ProcessorParameter parameter) const
     {
         float          value = 0.0f;
-        ::AicErrorCode rc = aic_processor_context_get_parameter(
+        ::AicErrorCode rc    = aic_processor_context_get_parameter(
             context_, static_cast<::AicProcessorParameter>(static_cast<int>(parameter)), &value);
         assert(rc == AIC_ERROR_CODE_SUCCESS);
         (void) rc;
@@ -476,10 +491,10 @@ class ProcessorContext
 
     // Constructor: creates an empty context wrapper for internal use when creation fails
     ProcessorContext() : context_(nullptr) {}
-    
-    // Constructor: wraps an existing SDK processor context handle; this instance becomes responsible for destroying it
-    explicit ProcessorContext(::AicProcessorContext* context) : context_(context) {}
 
+    // Constructor: wraps an existing SDK processor context handle; this instance becomes
+    // responsible for destroying it
+    explicit ProcessorContext(::AicProcessorContext* context) : context_(context) {}
 };
 
 // ---------------------------
@@ -507,7 +522,8 @@ class VadContext
         other.context_ = nullptr;
     }
 
-    // Move assignment: replaces the currently owned handle with the source handle and clears the source
+    // Move assignment: replaces the currently owned handle with the source handle and clears the
+    // source
     VadContext& operator=(VadContext&& other) noexcept
     {
         if (this != &other)
@@ -522,8 +538,9 @@ class VadContext
         return *this;
     }
 
-    // Deleted copy constructor: copying is disabled because this wrapper has unique ownership of the handle
-    VadContext(const VadContext&)            = delete;
+    // Deleted copy constructor: copying is disabled because this wrapper has unique ownership of
+    // the handle
+    VadContext(const VadContext&) = delete;
 
     // Deleted copy assignment: copying is disabled for the same reason as the copy constructor
     VadContext& operator=(const VadContext&) = delete;
@@ -582,7 +599,7 @@ class VadContext
     float get_parameter(VadParameter parameter) const
     {
         float          value = 0.0f;
-        ::AicErrorCode rc = aic_vad_context_get_parameter(
+        ::AicErrorCode rc    = aic_vad_context_get_parameter(
             context_, static_cast<::AicVadParameter>(static_cast<int>(parameter)), &value);
         assert(rc == AIC_ERROR_CODE_SUCCESS);
         (void) rc;
@@ -595,9 +612,9 @@ class VadContext
 
     // Constructor: creates an empty VAD context wrapper for internal use when creation fails
     VadContext() : context_(nullptr) {}
-    // Constructor: wraps an existing SDK VAD context handle; this instance becomes responsible for destroying it
+    // Constructor: wraps an existing SDK VAD context handle; this instance becomes responsible for
+    // destroying it
     explicit VadContext(::AicVadContext* context) : context_(context) {}
-
 };
 
 // ---------------------------
@@ -625,7 +642,8 @@ class Processor
         other.processor_ = nullptr;
     }
 
-    // Move assignment: replaces the currently owned handle with the source handle and clears the source
+    // Move assignment: replaces the currently owned handle with the source handle and clears the
+    // source
     Processor& operator=(Processor&& other) noexcept
     {
         if (this != &other)
@@ -640,8 +658,9 @@ class Processor
         return *this;
     }
 
-    // Deleted copy constructor: copying is disabled because this wrapper has unique ownership of the handle
-    Processor(const Processor&)            = delete;
+    // Deleted copy constructor: copying is disabled because this wrapper has unique ownership of
+    // the handle
+    Processor(const Processor&) = delete;
 
     // Deleted copy assignment: copying is disabled for the same reason as the copy constructor
     Processor& operator=(const Processor&) = delete;
@@ -712,7 +731,8 @@ class Processor
      */
     ErrorCode process_planar(float* const* audio, uint16_t num_channels, size_t num_frames)
     {
-        ::AicErrorCode rc = aic_processor_process_planar(processor_, audio, num_channels, num_frames);
+        ::AicErrorCode rc =
+            aic_processor_process_planar(processor_, audio, num_channels, num_frames);
         return static_cast<ErrorCode>(static_cast<int>(rc));
     }
 
@@ -740,7 +760,8 @@ class Processor
      */
     ErrorCode process_interleaved(float* audio, uint16_t num_channels, size_t num_frames)
     {
-        ::AicErrorCode rc = aic_processor_process_interleaved(processor_, audio, num_channels, num_frames);
+        ::AicErrorCode rc =
+            aic_processor_process_interleaved(processor_, audio, num_channels, num_frames);
         return static_cast<ErrorCode>(static_cast<int>(rc));
     }
 
@@ -768,7 +789,8 @@ class Processor
      */
     ErrorCode process_sequential(float* audio, uint16_t num_channels, size_t num_frames)
     {
-        ::AicErrorCode rc = aic_processor_process_sequential(processor_, audio, num_channels, num_frames);
+        ::AicErrorCode rc =
+            aic_processor_process_sequential(processor_, audio, num_channels, num_frames);
         return static_cast<ErrorCode>(static_cast<int>(rc));
     }
 
@@ -803,9 +825,9 @@ class Processor
   private:
     // Constructor: creates an empty Processor wrapper for internal use when creation fails
     Processor() : processor_(nullptr) {}
-    // Constructor: wraps an existing SDK processor handle; this instance becomes responsible for destroying it
+    // Constructor: wraps an existing SDK processor handle; this instance becomes responsible for
+    // destroying it
     explicit Processor(::AicProcessor* processor) : processor_(processor) {}
-
 };
 
 // ---------------------------

--- a/include/aic.hpp
+++ b/include/aic.hpp
@@ -65,6 +65,8 @@ struct Result
     Result(T&& v, ErrorCode e) : value(std::move(v)), error(e) {}
 
     bool ok() const { return error == ErrorCode::Success; }
+    // Helper: returns the contained value by move (useful for move-only types).
+    T take() { return std::move(value); }
 };
 
 /// Configurable parameters for audio enhancement

--- a/include/aic.hpp
+++ b/include/aic.hpp
@@ -299,57 +299,28 @@ class Model
 
 struct ProcessorConfig
 {
-    uint32_t sample_rate           = 0;
-    uint16_t num_channels          = 1;
-    size_t   num_frames            = 0;
-    bool     allow_variable_frames = false;
+    uint32_t sample_rate;
+    uint16_t num_channels;
+    size_t   num_frames;
+    bool     allow_variable_frames;
 
     /**
-     * Returns a ProcessorConfig pre-filled with the model's optimal sample rate and frame size.
+     * Constructs a ProcessorConfig with the specified parameters.
      *
-     * @param model Model instance used to query optimal settings.
-     * @return ProcessorConfig with the optimal sample rate and frame size.
-     *
-     * @note `num_channels` will be set to 1 and `allow_variable_frames` to false.
-     *       Adjust the number of channels and enable variable frames as needed.
+     * @param sample_rate Audio sample rate in Hz.
+     * @param num_frames Number of frames per processing block.
+     * @param num_channels Number of audio channels (1 for mono, 2 for stereo, etc.).
+     * @param allow_variable_frames True to enable variable frame sizes, false for fixed size.
      */
-    static ProcessorConfig optimal(const Model& model)
-    {
-        ProcessorConfig config;
-        config.sample_rate           = model.get_optimal_sample_rate();
-        config.num_frames            = model.get_optimal_num_frames(config.sample_rate);
-        config.num_channels          = 1;
-        config.allow_variable_frames = false;
-        return config;
-    }
-
-    /**
-     * Sets the number of audio channels for processing.
-     *
-     * @param channels Number of audio channels (1 for mono, 2 for stereo, etc.).
-     * @return Updated ProcessorConfig.
-     */
-    ProcessorConfig with_num_channels(uint16_t channels) const
-    {
-        ProcessorConfig copy = *this;
-        copy.num_channels    = channels;
-        return copy;
-    }
-
-    /**
-     * Enables or disables variable frame size support.
-     *
-     * When enabled, allows processing frame counts below num_frames at the cost of added latency.
-     *
-     * @param allow True to enable variable frame sizes, false for fixed size.
-     * @return Updated ProcessorConfig.
-     */
-    ProcessorConfig with_allow_variable_frames(bool allow) const
-    {
-        ProcessorConfig copy       = *this;
-        copy.allow_variable_frames = allow;
-        return copy;
-    }
+    ProcessorConfig(uint32_t sample_rate,
+                    size_t   num_frames,
+                    uint16_t num_channels          = 1,
+                    bool     allow_variable_frames = false)
+        : sample_rate(sample_rate)
+        , num_channels(num_channels)
+        , num_frames(num_frames)
+        , allow_variable_frames(allow_variable_frames)
+    {}
 };
 
 // ---------------------------

--- a/include/aic.hpp
+++ b/include/aic.hpp
@@ -11,7 +11,9 @@
 namespace aic
 {
 
-/// Error codes returned by SDK functions
+/**
+ * Error codes returned by SDK functions.
+ */
 enum class ErrorCode : int
 {
     /// Operation completed successfully
@@ -51,10 +53,17 @@ enum class ErrorCode : int
     ModelDataUnaligned = AIC_ERROR_CODE_MODEL_DATA_UNALIGNED,
 };
 
+/**
+ * Result wrapper for returning a value and an ErrorCode without exceptions.
+ *
+ * @tparam T Value type stored in the result.
+ */
 template <typename T>
 struct Result
 {
+    /// The returned value (may be default-constructed on failure).
     T         value;
+    /// Error status for the operation.
     ErrorCode error;
 
     // Default constructor: default-constructs the value and sets a non-success error as a safe sentinel
@@ -64,12 +73,15 @@ struct Result
     // Constructor: moves the value and stores the error code
     Result(T&& v, ErrorCode e) : value(std::move(v)), error(e) {}
 
+    /// Returns true when error == ErrorCode::Success.
     bool ok() const { return error == ErrorCode::Success; }
-    // Helper: returns the contained value by move (useful for move-only types).
+    /// Returns the contained value by move (useful for move-only types).
     T take() { return std::move(value); }
 };
 
-/// Configurable parameters for audio enhancement
+/**
+ * Configurable parameters for audio enhancement.
+ */
 enum class ProcessorParameter : int
 {
     /// Bypass keeping processing delay (0.0/1.0): 0.0=disabled, 1.0=enabled
@@ -80,7 +92,9 @@ enum class ProcessorParameter : int
     VoiceGain = AIC_PROCESSOR_PARAMETER_VOICE_GAIN,
 };
 
-/// Configurable parameters for voice activity detection (VAD)
+/**
+ * Configurable parameters for voice activity detection (VAD).
+ */
 enum class VadParameter : int
 {
     /// Controls for how long the VAD continues to detect speech after the audio signal no longer contains speech. (0.0 to 20x model window length in seconds)

--- a/include/aic.hpp
+++ b/include/aic.hpp
@@ -145,7 +145,7 @@ class Model
  * @param file_path Filesystem path to the model file (null-terminated string).
  * @return Result containing the Model and an ErrorCode.
  *
- * Possible errors (matches C API):
+ * Possible errors:
  * - ErrorCode::NullPointer
  * - ErrorCode::ModelInvalid
  * - ErrorCode::ModelVersionUnsupported
@@ -166,7 +166,7 @@ class Model
      * @param buffer_len Size of the model buffer in bytes.
      * @return Result containing the Model and an ErrorCode.
      *
-     * Possible errors (matches C API):
+     * Possible errors:
      * - ErrorCode::NullPointer
      * - ErrorCode::ModelInvalid
      * - ErrorCode::ModelVersionUnsupported
@@ -330,7 +330,7 @@ class ProcessorContext
     /**
      * Modifies a processor parameter.
      *
-     * Parameter ranges (see C API):
+     * Parameter ranges:
      * - Bypass: 0.0 or 1.0
      * - EnhancementLevel: 0.0 to 1.0
      * - VoiceGain: 0.1 to 4.0
@@ -453,7 +453,7 @@ class VadContext
     /**
      * Modifies a VAD parameter.
      *
-     * Parameter ranges (see C API):
+     * Parameter ranges:
      * - SpeechHoldDuration: 0.0 to 20x model window length (seconds)
      * - Sensitivity: 1.0 to 15.0
      * - MinimumSpeechDuration: 0.0 to 1.0 (seconds)
@@ -546,7 +546,7 @@ class Processor
      * @param license_key SDK license key (null-terminated string).
      * @return Result containing the Processor and an ErrorCode.
      *
-     * Possible errors (matches C API):
+     * Possible errors:
      * - ErrorCode::NullPointer
      * - ErrorCode::LicenseFormatInvalid
      * - ErrorCode::LicenseVersionUnsupported

--- a/include/aic.hpp
+++ b/include/aic.hpp
@@ -24,7 +24,7 @@ enum class ErrorCode : int
     ParameterOutOfRange = AIC_ERROR_CODE_PARAMETER_OUT_OF_RANGE,
     /// Processor must be initialized before calling this operation. Call Processor::initialize
     /// first.
-    ModelNotInitialized = AIC_ERROR_CODE_MODEL_NOT_INITIALIZED,
+    ProcessorNotInitialized = AIC_ERROR_CODE_PROCESSOR_NOT_INITIALIZED,
     /// Audio configuration (samplerate, num_channels, num_frames) is not supported by the model.
     AudioConfigUnsupported = AIC_ERROR_CODE_AUDIO_CONFIG_UNSUPPORTED,
     /// Audio buffer configuration differs from the one provided during initialization.
@@ -149,7 +149,7 @@ enum class VadParameter : int
      * length of 10 ms, the VAD will round up/down to the closest multiple of 10 ms.
      * Because of this, this parameter may return a different value than the one it was last set to.
      *
-     * **Range:** 0.0 to 20x model window length (value in seconds)
+     * **Range:** 0.0 to 100x model window length (value in seconds)
      *
      * **Default:** 0.05 (50 ms)
      */

--- a/include/aic.hpp
+++ b/include/aic.hpp
@@ -57,11 +57,11 @@ struct Result
     T         value;
     ErrorCode error;
 
-    // Default-constructs the value and sets a non-success error as a safe sentinel.
+    // Default constructor: default-constructs the value and sets a non-success error as a safe sentinel
     Result() : value(), error(ErrorCode::InternalError) {}
-    // Constructs a Result by copying the value and storing the error code.
+    // Constructor: copies the value and stores the error code
     Result(const T& v, ErrorCode e) : value(v), error(e) {}
-    // Constructs a Result by moving the value and storing the error code.
+    // Constructor: moves the value and stores the error code
     Result(T&& v, ErrorCode e) : value(std::move(v)), error(e) {}
 
     bool ok() const { return error == ErrorCode::Success; }
@@ -151,7 +151,7 @@ class Model
     ::AicModel* model_;
 
   public:
-    // Releases the underlying SDK model handle if one is owned.
+    // Destructor: releases the underlying SDK model handle if one is owned
     ~Model()
     {
         if (model_)
@@ -160,13 +160,13 @@ class Model
         }
     }
 
-    // Transfers ownership of the model handle from another Model (the source becomes empty).
+    // Move constructor: the handle from the source Model gets moved into the new Model
     Model(Model&& other) noexcept : model_(other.model_)
     {
         other.model_ = nullptr;
     }
 
-    // Replaces the currently owned handle with another Model's handle, cleaning up the old one.
+    // Move assignment: replaces the currently owned handle with the source handle and clears the source
     Model& operator=(Model&& other) noexcept
     {
         if (this != &other)
@@ -181,9 +181,10 @@ class Model
         return *this;
     }
 
-    // Copying is disabled because this wrapper has unique ownership of the handle.
+    // Deleted copy constructor: copying is disabled because this wrapper has unique ownership of the handle
     Model(const Model&)            = delete;
-    // Copy assignment is disabled for the same reason as the copy constructor.
+
+    // Deleted copy assignment: copying is disabled for the same reason as the copy constructor
     Model& operator=(const Model&) = delete;
 
     // Internal accessor for C API interop
@@ -254,7 +255,7 @@ class ProcessorContext
     ::AicProcessorContext* context_;
 
   public:
-    // Releases the underlying SDK processor context handle if one is owned.
+    // Destructor: releases the underlying SDK processor context handle if one is owned
     ~ProcessorContext()
     {
         if (context_)
@@ -263,13 +264,13 @@ class ProcessorContext
         }
     }
 
-    // Transfers ownership of the context handle from another ProcessorContext (the source becomes empty).
+    // Move constructor: the handle from the source ProcessorContext gets moved into the new ProcessorContext
     ProcessorContext(ProcessorContext&& other) noexcept : context_(other.context_)
     {
         other.context_ = nullptr;
     }
 
-    // Replaces the currently owned handle with another context handle, cleaning up the old one.
+    // Move assignment: replaces the currently owned handle with the source handle and clears the source
     ProcessorContext& operator=(ProcessorContext&& other) noexcept
     {
         if (this != &other)
@@ -284,9 +285,10 @@ class ProcessorContext
         return *this;
     }
 
-    // Copying is disabled because this wrapper has unique ownership of the handle.
+    // Deleted copy constructor: copying is disabled because this wrapper has unique ownership of the handle
     ProcessorContext(const ProcessorContext&)            = delete;
-    // Copy assignment is disabled for the same reason as the copy constructor.
+
+    // Deleted copy assignment: copying is disabled for the same reason as the copy constructor
     ProcessorContext& operator=(const ProcessorContext&) = delete;
 
     /**
@@ -332,12 +334,13 @@ class ProcessorContext
     }
 
   private:
-    // Allows Processor to construct ProcessorContext instances from raw handles.
+    // Friend declaration: allows Processor to construct ProcessorContext instances from raw handles
     friend class Processor;
 
-    // Creates an empty context wrapper for internal use when creation fails.
+    // Constructor: creates an empty context wrapper for internal use when creation fails
     ProcessorContext() : context_(nullptr) {}
-    // Wraps an existing SDK processor context handle; this instance becomes responsible for destroying it.
+    
+    // Constructor: wraps an existing SDK processor context handle; this instance becomes responsible for destroying it
     explicit ProcessorContext(::AicProcessorContext* context) : context_(context) {}
 
 };
@@ -352,7 +355,7 @@ class VadContext
     ::AicVadContext* context_;
 
   public:
-    // Releases the underlying SDK VAD context handle if one is owned.
+    // Destructor: releases the underlying SDK VAD context handle if one is owned
     ~VadContext()
     {
         if (context_)
@@ -361,13 +364,13 @@ class VadContext
         }
     }
 
-    // Transfers ownership of the context handle from another VadContext (the source becomes empty).
+    // Move constructor: the handle from the source VadContext gets moved into the new VadContext
     VadContext(VadContext&& other) noexcept : context_(other.context_)
     {
         other.context_ = nullptr;
     }
 
-    // Replaces the currently owned handle with another context handle, cleaning up the old one.
+    // Move assignment: replaces the currently owned handle with the source handle and clears the source
     VadContext& operator=(VadContext&& other) noexcept
     {
         if (this != &other)
@@ -382,9 +385,10 @@ class VadContext
         return *this;
     }
 
-    // Copying is disabled because this wrapper has unique ownership of the handle.
+    // Deleted copy constructor: copying is disabled because this wrapper has unique ownership of the handle
     VadContext(const VadContext&)            = delete;
-    // Copy assignment is disabled for the same reason as the copy constructor.
+
+    // Deleted copy assignment: copying is disabled for the same reason as the copy constructor
     VadContext& operator=(const VadContext&) = delete;
 
     /**
@@ -421,12 +425,12 @@ class VadContext
     }
 
   private:
-    // Allows Processor to construct VadContext instances from raw handles.
+    // Friend declaration: allows Processor to construct VadContext instances from raw handles
     friend class Processor;
 
-    // Creates an empty VAD context wrapper for internal use when creation fails.
+    // Constructor: creates an empty VAD context wrapper for internal use when creation fails
     VadContext() : context_(nullptr) {}
-    // Wraps an existing SDK VAD context handle; this instance becomes responsible for destroying it.
+    // Constructor: wraps an existing SDK VAD context handle; this instance becomes responsible for destroying it
     explicit VadContext(::AicVadContext* context) : context_(context) {}
 
 };
@@ -441,7 +445,7 @@ class Processor
     ::AicProcessor* processor_;
 
   public:
-    // Releases the underlying SDK processor handle if one is owned.
+    // Destructor: releases the underlying SDK processor handle if one is owned
     ~Processor()
     {
         if (processor_)
@@ -450,13 +454,13 @@ class Processor
         }
     }
 
-    // Transfers ownership of the processor handle from another Processor (the source becomes empty).
+    // Move constructor: the handle from the source Processor gets moved into the new Processor
     Processor(Processor&& other) noexcept : processor_(other.processor_)
     {
         other.processor_ = nullptr;
     }
 
-    // Replaces the currently owned handle with another processor handle, cleaning up the old one.
+    // Move assignment: replaces the currently owned handle with the source handle and clears the source
     Processor& operator=(Processor&& other) noexcept
     {
         if (this != &other)
@@ -471,9 +475,10 @@ class Processor
         return *this;
     }
 
-    // Copying is disabled because this wrapper has unique ownership of the handle.
+    // Deleted copy constructor: copying is disabled because this wrapper has unique ownership of the handle
     Processor(const Processor&)            = delete;
-    // Copy assignment is disabled for the same reason as the copy constructor.
+
+    // Deleted copy assignment: copying is disabled for the same reason as the copy constructor
     Processor& operator=(const Processor&) = delete;
 
     /**
@@ -530,9 +535,9 @@ class Processor
     Result<VadContext> create_vad_context() const;
 
   private:
-    // Creates an empty Processor wrapper for internal use when creation fails.
+    // Constructor: creates an empty Processor wrapper for internal use when creation fails
     Processor() : processor_(nullptr) {}
-    // Wraps an existing SDK processor handle; this instance becomes responsible for destroying it.
+    // Constructor: wraps an existing SDK processor handle; this instance becomes responsible for destroying it
     explicit Processor(::AicProcessor* processor) : processor_(processor) {}
 
 };

--- a/include/aic.hpp
+++ b/include/aic.hpp
@@ -90,30 +90,6 @@ enum class VadParameter : int
 };
 
 // ---------------------------
-// Internal enum conversions
-// ---------------------------
-
-inline constexpr ::AicErrorCode to_c(ErrorCode e)
-{
-    return static_cast<::AicErrorCode>(static_cast<int>(e));
-}
-
-inline constexpr ::AicProcessorParameter to_c(ProcessorParameter p)
-{
-    return static_cast<::AicProcessorParameter>(static_cast<int>(p));
-}
-
-inline constexpr ::AicVadParameter to_c(VadParameter p)
-{
-    return static_cast<::AicVadParameter>(static_cast<int>(p));
-}
-
-inline constexpr ErrorCode to_cpp(::AicErrorCode e)
-{
-    return static_cast<ErrorCode>(static_cast<int>(e));
-}
-
-// ---------------------------
 // Configuration
 // ---------------------------
 
@@ -295,7 +271,7 @@ class ProcessorContext
     ErrorCode reset() const
     {
         ::AicErrorCode rc = aic_processor_context_reset(context_);
-        return to_cpp(rc);
+        return static_cast<ErrorCode>(static_cast<int>(rc));
     }
 
     /**
@@ -303,8 +279,9 @@ class ProcessorContext
      */
     ErrorCode set_parameter(ProcessorParameter parameter, float value) const
     {
-        ::AicErrorCode rc = aic_processor_context_set_parameter(context_, to_c(parameter), value);
-        return to_cpp(rc);
+        ::AicErrorCode rc = aic_processor_context_set_parameter(
+            context_, static_cast<::AicProcessorParameter>(static_cast<int>(parameter)), value);
+        return static_cast<ErrorCode>(static_cast<int>(rc));
     }
 
     /**
@@ -313,7 +290,8 @@ class ProcessorContext
     float get_parameter(ProcessorParameter parameter) const
     {
         float          value = 0.0f;
-        ::AicErrorCode rc = aic_processor_context_get_parameter(context_, to_c(parameter), &value);
+        ::AicErrorCode rc = aic_processor_context_get_parameter(
+            context_, static_cast<::AicProcessorParameter>(static_cast<int>(parameter)), &value);
         assert(rc == AIC_ERROR_CODE_SUCCESS);
         (void) rc;
         return value;
@@ -406,8 +384,9 @@ class VadContext
      */
     ErrorCode set_parameter(VadParameter parameter, float value) const
     {
-        ::AicErrorCode rc = aic_vad_context_set_parameter(context_, to_c(parameter), value);
-        return to_cpp(rc);
+        ::AicErrorCode rc = aic_vad_context_set_parameter(
+            context_, static_cast<::AicVadParameter>(static_cast<int>(parameter)), value);
+        return static_cast<ErrorCode>(static_cast<int>(rc));
     }
 
     /**
@@ -416,7 +395,8 @@ class VadContext
     float get_parameter(VadParameter parameter) const
     {
         float          value = 0.0f;
-        ::AicErrorCode rc = aic_vad_context_get_parameter(context_, to_c(parameter), &value);
+        ::AicErrorCode rc = aic_vad_context_get_parameter(
+            context_, static_cast<::AicVadParameter>(static_cast<int>(parameter)), &value);
         assert(rc == AIC_ERROR_CODE_SUCCESS);
         (void) rc;
         return value;
@@ -492,7 +472,7 @@ class Processor
     {
         ::AicErrorCode rc = aic_processor_initialize(processor_, sample_rate, num_channels,
                                                      num_frames, allow_variable_frames);
-        return to_cpp(rc);
+        return static_cast<ErrorCode>(static_cast<int>(rc));
     }
 
     /**
@@ -501,7 +481,7 @@ class Processor
     ErrorCode process_planar(float* const* audio, uint16_t num_channels, size_t num_frames)
     {
         ::AicErrorCode rc = aic_processor_process_planar(processor_, audio, num_channels, num_frames);
-        return to_cpp(rc);
+        return static_cast<ErrorCode>(static_cast<int>(rc));
     }
 
     /**
@@ -510,7 +490,7 @@ class Processor
     ErrorCode process_interleaved(float* audio, uint16_t num_channels, size_t num_frames)
     {
         ::AicErrorCode rc = aic_processor_process_interleaved(processor_, audio, num_channels, num_frames);
-        return to_cpp(rc);
+        return static_cast<ErrorCode>(static_cast<int>(rc));
     }
 
     /**
@@ -519,7 +499,7 @@ class Processor
     ErrorCode process_sequential(float* audio, uint16_t num_channels, size_t num_frames)
     {
         ::AicErrorCode rc = aic_processor_process_sequential(processor_, audio, num_channels, num_frames);
-        return to_cpp(rc);
+        return static_cast<ErrorCode>(static_cast<int>(rc));
     }
 
     /**

--- a/include/aic.hpp
+++ b/include/aic.hpp
@@ -187,11 +187,6 @@ class Model
     // Deleted copy assignment: copying is disabled for the same reason as the copy constructor
     Model& operator=(const Model&) = delete;
 
-    // Internal accessor for C API interop
-    ::AicModel* get_c_model() const { return model_; }
-
-    bool is_valid() const { return model_ != nullptr; }
-
     /**
      * Creates a new model instance from a file path.
      */
@@ -238,6 +233,9 @@ class Model
     }
 
   private:
+    // Friend declaration: allows Processor to access the raw model handle for creation.
+    friend class Processor;
+
     // Creates an empty Model wrapper for internal use when creation fails.
     Model() : model_(nullptr) {}
     // Wraps an existing SDK model handle; this instance becomes responsible for destroying it.

--- a/release/ReleaseNotes.md
+++ b/release/ReleaseNotes.md
@@ -24,6 +24,7 @@ This release comes with a number of new features and several breaking changes. M
 - A single model instance can be shared across multiple processors.
 - Added `aic::Processor::create` so each stream can be initialized independently from a shared model while sharing weights.
 - Added `aic::get_compatible_model_version` to query the required model version for this SDK.
+- VAD speech hold duration parameter cap was increased to 100x the model's window length.
 - Added context-based APIs for thread-safe control operations:
     - `aic::ProcessorContext` for processor control and queries
     - `aic::VadContext` for VAD control and queries
@@ -53,12 +54,12 @@ This release comes with a number of new features and several breaking changes. M
 - VAD APIs now use `aic::VadContext` created from a processor.
 - Processor control APIs now live on `aic::ProcessorContext` (reset, parameter access, output delay).
 - Model query APIs now live on `aic::Model` (optimal sample rate/frames).
-- C++ wrapper breaking changes:
-    - `aic::AicModel` wrapper replaced by `aic::Model` + `aic::Processor`
-    - Model selection by enum removed; supply a model file or aligned buffer
-    - Parameter/reset/output delay APIs now live on `aic::ProcessorContext`
-    - VAD APIs now use `aic::VadContext` created from a processor
-    - `std::pair`/`std::unique_ptr` creation patterns replaced by `aic::Result<T>` + `take()`
+- `ErrorCode::ModelNotInitialized` was renamed to `ErrorCode::ProcessorNotInitialized`.
+- `aic::AicModel` wrapper replaced by `aic::Model` + `aic::Processor`
+- Model selection by enum removed; supply a model file or aligned buffer
+- Parameter/reset/output delay APIs now live on `aic::ProcessorContext`
+- VAD APIs now use `aic::VadContext` created from a processor
+- `std::pair`/`std::unique_ptr` creation patterns replaced by `aic::Result<T>` + `take()`
 
 ## Fixes
 

--- a/release/ReleaseNotes.md
+++ b/release/ReleaseNotes.md
@@ -4,55 +4,61 @@ This release comes with a number of new features and several breaking changes. M
 
 **Model naming changes**: Quail-STT models are now called "Quail" - These models are optimized for human-to-machine enhancement (e.g., Speech-to-Text (STT) applications). Quail models are now called "Sparrow" - These models are optimized for human-to-human enhancement (e.g., voice calls, conferencing). This naming change clarifies the distinction between STT-focused models and human-to-human communication model
 
-**Major architectural changes**: The API has been restructured to separate model data from processing instances. What was previously called `AicModel` (which handled both model data and processing) has been split into:
-- `AicModel`: Now represents only the ML model data loaded from files or memory
-- `AicProcessor`: New type that performs the actual audio processing using a model
+**Major architectural changes**: The API has been restructured to separate model data from processing instances. What was previously called `aic::AicModel` (which handled both model data and processing) has been split into:
+- `aic::Model`: Now represents only the ML model data loaded from files or memory
+- `aic::Processor`: New type that performs the actual audio processing using a model
 - Multiple processors can share the same model, allowing efficient resource usage across streams
-- Model instances are reference-counted internally; `aic_model_destroy` can be called immediately after creating processors, and the model will be freed automatically when the last processor using it is destroyed
-- To change parameters, reset the processor and get the output delay, a processor context must now be created via `aic_processor_context_create`. This context can be freely moved between threads
+- Models can be destroyed after creating processors; memory is freed when the last processor using them is destroyed
+- To change parameters, reset the processor and get output delay, create a `aic::ProcessorContext`. This context can be freely moved between threads
+
+**C++ wrapper alignment**: The C++ API mirrors these changes:
+- `aic::Model` holds model data; `aic::Processor` performs processing using a model
+- `aic::ProcessorContext` and `aic::VadContext` are created from a processor for thread-safe control APIs
+- `aic::ProcessorConfig` helps construct optimal configs from a model
 
 ## New features
 
-- Models now load from files via `aic_model_create_from_file`.
-- Models can also be created from in-memory buffers with `aic_model_create_from_buffer`.
-- Added new `aic_model_get_id` API to query the id of a model.
-- A single model handle can be shared across multiple processors.
-- Added processor handles with `aic_processor_create` so each stream can be initialized independently from a shared model while sharing weights.
-- Added `aic_get_compatible_model_version` to query the required model version for this SDK.
+- Models now load from files via `aic::Model::create_from_file`.
+- Models can also be created from in-memory buffers with `aic::Model::create_from_buffer`.
+- Added `aic::Model::get_id` to query the id of a model.
+- A single model instance can be shared across multiple processors.
+- Added `aic::Processor::create` so each stream can be initialized independently from a shared model while sharing weights.
+- Added `aic::get_compatible_model_version` to query the required model version for this SDK.
 - Added context-based APIs for thread-safe control operations:
-    - `aic_processor_context_create` and `aic_processor_context_destroy` for processor context management
-    - `aic_vad_context_create` and `aic_vad_context_destroy` for VAD context management
-- Model query APIs moved to model handles:
-    - `aic_model_get_optimal_sample_rate` - gets optimal sample rate for a model
-    - `aic_model_get_optimal_num_frames` - gets optimal frame count for a model at given sample rate
-- Added new error codes for model loading:
-    - `AIC_ERROR_CODE_MODEL_INVALID`
-    - `AIC_ERROR_CODE_MODEL_VERSION_UNSUPPORTED`
-    - `AIC_ERROR_CODE_MODEL_FILE_PATH_INVALID`
-    - `AIC_ERROR_CODE_FILE_SYSTEM_ERROR`
-    - `AIC_ERROR_CODE_MODEL_DATA_UNALIGNED`
+    - `aic::ProcessorContext` for processor control and queries
+    - `aic::VadContext` for VAD control and queries
+- Model query APIs moved to model methods:
+    - `aic::Model::get_optimal_sample_rate` - gets optimal sample rate for a model
+    - `aic::Model::get_optimal_num_frames` - gets optimal frame count for a model at given sample rate
+- Added new error codes for model loading (see `aic::ErrorCode`):
+    - `ErrorCode::ModelInvalid`
+    - `ErrorCode::ModelVersionUnsupported`
+    - `ErrorCode::ModelFilePathInvalid`
+    - `ErrorCode::FileSystemError`
+    - `ErrorCode::ModelDataUnaligned`
+- C++ wrapper additions:
+    - `aic::Model::create_from_file` and `aic::Model::create_from_buffer`
+    - `aic::Processor::create` plus `aic::ProcessorContext` and `aic::VadContext`
+    - `aic::Model::get_id`, `aic::Model::get_optimal_sample_rate`, `aic::Model::get_optimal_num_frames`
+    - `aic::get_compatible_model_version` and `aic::get_sdk_version`
+    - `aic::Result<T>` return type for error handling without exceptions
 
 ## Breaking changes
 
 - License keys previously generated in the [development portal](developers.ai-coustics.io) will no longer work. New license keys have to be generated.
-- Existing `aic_model_*` processing and configuration APIs have been renamed to `aic_processor_*`.
-- Removed `AicModelType` enum; callers must supply a model file or aligned buffer instead of selecting a built-in model.
-- License keys are now provided to `aic_processor_create` rather than model creation.
-- Renamed `AicEnhancementParameter` to `AicProcessorParameter` (`AIC_PROCESSOR_PARAMETER_*`).
-- VAD APIs now use `AicVadContext` handles and bind to processor handles instead of model handles:
-    - `aic_vad_create` → `aic_vad_context_create` (takes `const AicProcessor*` instead of `AicModel*`)
-    - `aic_vad_destroy` → `aic_vad_context_destroy`
-    - `aic_vad_is_speech_detected` → `aic_vad_context_is_speech_detected` (takes `const AicVadContext*`)
-    - `aic_vad_get_parameter` → `aic_vad_context_get_parameter` (takes `const AicVadContext*`)
-    - `aic_vad_set_parameter` → `aic_vad_context_set_parameter` (takes `const AicVadContext*`)
-- Processor control APIs now take `AicProcessorContext` handles created via `aic_processor_context_create`:
-    - `aic_model_reset` → `aic_processor_context_reset` (takes `const AicProcessorContext*`)
-    - `aic_model_get_parameter` → `aic_processor_context_get_parameter` (takes `const AicProcessorContext*`)
-    - `aic_model_set_parameter` → `aic_processor_context_set_parameter` (takes `const AicProcessorContext*`)
-    - `aic_get_output_delay` → `aic_processor_context_get_output_delay` (takes `const AicProcessorContext*`)
-- Model query APIs moved to model methods:
-    - `aic_get_optimal_sample_rate` → `aic_model_get_optimal_sample_rate`
-    - `aic_get_optimal_num_frames` → `aic_model_get_optimal_num_frames`
+- Existing model-processing combined API has been split into `aic::Model` and `aic::Processor`.
+- Removed `aic::ModelType` enum; callers must supply a model file or aligned buffer instead of selecting a built-in model.
+- License keys are now provided to `aic::Processor::create` rather than model creation.
+- Renamed `aic::Parameter` to `aic::ProcessorParameter`.
+- VAD APIs now use `aic::VadContext` created from a processor.
+- Processor control APIs now live on `aic::ProcessorContext` (reset, parameter access, output delay).
+- Model query APIs now live on `aic::Model` (optimal sample rate/frames).
+- C++ wrapper breaking changes:
+    - `aic::AicModel` wrapper replaced by `aic::Model` + `aic::Processor`
+    - Model selection by enum removed; supply a model file or aligned buffer
+    - Parameter/reset/output delay APIs now live on `aic::ProcessorContext`
+    - VAD APIs now use `aic::VadContext` created from a processor
+    - `std::pair`/`std::unique_ptr` creation patterns replaced by `aic::Result<T>` + `take()`
 
 ## Fixes
 

--- a/release/ReleaseNotes.md
+++ b/release/ReleaseNotes.md
@@ -45,7 +45,7 @@ This release comes with a number of new features and several breaking changes. M
 
 ## Breaking changes
 
-- License keys previously generated in the [development portal](developers.ai-coustics.io) will no longer work. New license keys have to be generated.
+- License keys previously generated in the [developer portal](developers.ai-coustics.io) will no longer work. New license keys have to be generated.
 - Existing model-processing combined API has been split into `aic::Model` and `aic::Processor`.
 - Removed `aic::ModelType` enum; callers must supply a model file or aligned buffer instead of selecting a built-in model.
 - License keys are now provided to `aic::Processor::create` rather than model creation.

--- a/release/ReleaseNotes.md
+++ b/release/ReleaseNotes.md
@@ -14,7 +14,7 @@ This release comes with a number of new features and several breaking changes. M
 **C++ wrapper alignment**: The C++ API mirrors these changes:
 - `aic::Model` holds model data; `aic::Processor` performs processing using a model
 - `aic::ProcessorContext` and `aic::VadContext` are created from a processor for thread-safe control APIs
-- `aic::ProcessorConfig` helps construct optimal configs from a model
+- `aic::ProcessorConfig` struct holds audio configuration (sample rate, channels, frames, variable frame support)
 
 ## New features
 

--- a/release/ReleaseNotes.md
+++ b/release/ReleaseNotes.md
@@ -1,7 +1,60 @@
-### Features
+This release comes with a number of new features and several breaking changes. Most notably, the C library does no longer include any models, which significantly reduces the library's binary size. The models are now available separately for download at https://artifacts.ai-coustics.io.
 
-- **New VAD parameter `VadParameter::MinimumSpeechDuration`**: Controls for how long speech needs to be present in the audio signal before the VAD considers it speech (0.0 - 1.0 seconds).
+**New license keys required**: License keys previously generated in the [developer portal](https://developers.ai-coustics.io) will no longer work. New license keys must be generated.
 
-### Breaking Changes
+**Model naming changes**: Quail-STT models are now called "Quail" - These models are optimized for human-to-machine enhancement (e.g., Speech-to-Text (STT) applications). Quail models are now called "Sparrow" - These models are optimized for human-to-human enhancement (e.g., voice calls, conferencing). This naming change clarifies the distinction between STT-focused models and human-to-human communication model
 
-- **Replaced VAD parameter `VadParameter::LookbackBufferSize` with `VadParameter::SpeechHoldDuration`**: The new parameter controls for how long the VAD continues to detect speech after the audio signal no longer contains speech (0.0 to 20x model window length in seconds).
+**Major architectural changes**: The API has been restructured to separate model data from processing instances. What was previously called `AicModel` (which handled both model data and processing) has been split into:
+- `AicModel`: Now represents only the ML model data loaded from files or memory
+- `AicProcessor`: New type that performs the actual audio processing using a model
+- Multiple processors can share the same model, allowing efficient resource usage across streams
+- Model instances are reference-counted internally; `aic_model_destroy` can be called immediately after creating processors, and the model will be freed automatically when the last processor using it is destroyed
+- To change parameters, reset the processor and get the output delay, a processor context must now be created via `aic_processor_context_create`. This context can be freely moved between threads
+
+## New features
+
+- Models now load from files via `aic_model_create_from_file`.
+- Models can also be created from in-memory buffers with `aic_model_create_from_buffer`.
+- Added new `aic_model_get_id` API to query the id of a model.
+- A single model handle can be shared across multiple processors.
+- Added processor handles with `aic_processor_create` so each stream can be initialized independently from a shared model while sharing weights.
+- Added `aic_get_compatible_model_version` to query the required model version for this SDK.
+- Added context-based APIs for thread-safe control operations:
+    - `aic_processor_context_create` and `aic_processor_context_destroy` for processor context management
+    - `aic_vad_context_create` and `aic_vad_context_destroy` for VAD context management
+- Model query APIs moved to model handles:
+    - `aic_model_get_optimal_sample_rate` - gets optimal sample rate for a model
+    - `aic_model_get_optimal_num_frames` - gets optimal frame count for a model at given sample rate
+- Added new error codes for model loading:
+    - `AIC_ERROR_CODE_MODEL_INVALID`
+    - `AIC_ERROR_CODE_MODEL_VERSION_UNSUPPORTED`
+    - `AIC_ERROR_CODE_MODEL_FILE_PATH_INVALID`
+    - `AIC_ERROR_CODE_FILE_SYSTEM_ERROR`
+    - `AIC_ERROR_CODE_MODEL_DATA_UNALIGNED`
+
+## Breaking changes
+
+- License keys previously generated in the [development portal](developers.ai-coustics.io) will no longer work. New license keys have to be generated.
+- Existing `aic_model_*` processing and configuration APIs have been renamed to `aic_processor_*`.
+- Removed `AicModelType` enum; callers must supply a model file or aligned buffer instead of selecting a built-in model.
+- License keys are now provided to `aic_processor_create` rather than model creation.
+- Renamed `AicEnhancementParameter` to `AicProcessorParameter` (`AIC_PROCESSOR_PARAMETER_*`).
+- VAD APIs now use `AicVadContext` handles and bind to processor handles instead of model handles:
+    - `aic_vad_create` → `aic_vad_context_create` (takes `const AicProcessor*` instead of `AicModel*`)
+    - `aic_vad_destroy` → `aic_vad_context_destroy`
+    - `aic_vad_is_speech_detected` → `aic_vad_context_is_speech_detected` (takes `const AicVadContext*`)
+    - `aic_vad_get_parameter` → `aic_vad_context_get_parameter` (takes `const AicVadContext*`)
+    - `aic_vad_set_parameter` → `aic_vad_context_set_parameter` (takes `const AicVadContext*`)
+- Processor control APIs now take `AicProcessorContext` handles created via `aic_processor_context_create`:
+    - `aic_model_reset` → `aic_processor_context_reset` (takes `const AicProcessorContext*`)
+    - `aic_model_get_parameter` → `aic_processor_context_get_parameter` (takes `const AicProcessorContext*`)
+    - `aic_model_set_parameter` → `aic_processor_context_set_parameter` (takes `const AicProcessorContext*`)
+    - `aic_get_output_delay` → `aic_processor_context_get_output_delay` (takes `const AicProcessorContext*`)
+- Model query APIs moved to model methods:
+    - `aic_get_optimal_sample_rate` → `aic_model_get_optimal_sample_rate`
+    - `aic_get_optimal_num_frames` → `aic_model_get_optimal_num_frames`
+
+## Fixes
+
+- Improved thread safety.
+- Fixed an issue where the allocated size for an FFT operation could be incorrect, leading to a crash.

--- a/src/aic.cpp
+++ b/src/aic.cpp
@@ -5,8 +5,33 @@ extern "C" void aic_set_sdk_wrapper_id(uint32_t id);
 namespace aic
 {
 
-std::pair<std::unique_ptr<AicModel>, ErrorCode>
-AicModel::create(ModelType model_type, const std::string& license_key)
+Result<Model> Model::create_from_file(const std::string& file_path)
+{
+    ::AicModel*    raw_model = nullptr;
+    ::AicErrorCode rc        = aic_model_create_from_file(&raw_model, file_path.c_str());
+
+    if (rc == AIC_ERROR_CODE_SUCCESS)
+    {
+        return Result<Model>(Model(raw_model), ErrorCode::Success);
+    }
+
+    return Result<Model>(Model(), to_cpp(rc));
+}
+
+Result<Model> Model::create_from_buffer(const uint8_t* buffer, size_t buffer_len)
+{
+    ::AicModel*    raw_model = nullptr;
+    ::AicErrorCode rc        = aic_model_create_from_buffer(&raw_model, buffer, buffer_len);
+
+    if (rc == AIC_ERROR_CODE_SUCCESS)
+    {
+        return Result<Model>(Model(raw_model), ErrorCode::Success);
+    }
+
+    return Result<Model>(Model(), to_cpp(rc));
+}
+
+Result<Processor> Processor::create(const Model& model, const std::string& license_key)
 {
     static const bool wrapper_id_set = []() {
         aic_set_sdk_wrapper_id(1);
@@ -14,29 +39,42 @@ AicModel::create(ModelType model_type, const std::string& license_key)
     }();
     (void) wrapper_id_set;
 
-    ::AicModel*    raw_model = nullptr;
-    ::AicErrorCode rc        = aic_model_create(&raw_model, to_c(model_type), license_key.c_str());
+    ::AicProcessor* raw_processor = nullptr;
+    ::AicErrorCode  rc =
+        aic_processor_create(&raw_processor, model.get_c_model(), license_key.c_str());
 
     if (rc == AIC_ERROR_CODE_SUCCESS)
     {
-        return {std::unique_ptr<AicModel>(new AicModel(raw_model)), ErrorCode::Success};
+        return Result<Processor>(Processor(raw_processor), ErrorCode::Success);
     }
 
-    return {std::unique_ptr<AicModel>(), to_cpp(rc)};
+    return Result<Processor>(Processor(), to_cpp(rc));
 }
 
-std::pair<std::unique_ptr<AicVad>, ErrorCode>
-AicVad::create(AicModel& model)
+Result<ProcessorContext> Processor::create_context() const
 {
-    ::AicVad*      raw_vad = nullptr;
-    ::AicErrorCode rc      = aic_vad_create(&raw_vad, model.get_c_model());
+    ::AicProcessorContext* raw_context = nullptr;
+    ::AicErrorCode rc = aic_processor_context_create(&raw_context, processor_);
 
     if (rc == AIC_ERROR_CODE_SUCCESS)
     {
-        return {std::unique_ptr<AicVad>(new AicVad(raw_vad)), ErrorCode::Success};
+        return Result<ProcessorContext>(ProcessorContext(raw_context), ErrorCode::Success);
     }
 
-    return {std::unique_ptr<AicVad>(), to_cpp(rc)};
+    return Result<ProcessorContext>(ProcessorContext(), to_cpp(rc));
+}
+
+Result<VadContext> Processor::create_vad_context() const
+{
+    ::AicVadContext* raw_context = nullptr;
+    ::AicErrorCode   rc          = aic_vad_context_create(&raw_context, processor_);
+
+    if (rc == AIC_ERROR_CODE_SUCCESS)
+    {
+        return Result<VadContext>(VadContext(raw_context), ErrorCode::Success);
+    }
+
+    return Result<VadContext>(VadContext(), to_cpp(rc));
 }
 
 } // namespace aic

--- a/src/aic.cpp
+++ b/src/aic.cpp
@@ -40,8 +40,8 @@ Result<Processor> Processor::create(const Model& model, const std::string& licen
     (void) wrapper_id_set;
 
     ::AicProcessor* raw_processor = nullptr;
-    ::AicErrorCode  rc =
-        aic_processor_create(&raw_processor, model.get_c_model(), license_key.c_str());
+    ::AicErrorCode rc =
+        aic_processor_create(&raw_processor, model.model_, license_key.c_str());
 
     if (rc == AIC_ERROR_CODE_SUCCESS)
     {

--- a/src/aic.cpp
+++ b/src/aic.cpp
@@ -15,7 +15,7 @@ Result<Model> Model::create_from_file(const std::string& file_path)
         return Result<Model>(Model(raw_model), ErrorCode::Success);
     }
 
-    return Result<Model>(Model(), to_cpp(rc));
+    return Result<Model>(Model(), static_cast<ErrorCode>(static_cast<int>(rc)));
 }
 
 Result<Model> Model::create_from_buffer(const uint8_t* buffer, size_t buffer_len)
@@ -28,7 +28,7 @@ Result<Model> Model::create_from_buffer(const uint8_t* buffer, size_t buffer_len
         return Result<Model>(Model(raw_model), ErrorCode::Success);
     }
 
-    return Result<Model>(Model(), to_cpp(rc));
+    return Result<Model>(Model(), static_cast<ErrorCode>(static_cast<int>(rc)));
 }
 
 Result<Processor> Processor::create(const Model& model, const std::string& license_key)
@@ -48,7 +48,7 @@ Result<Processor> Processor::create(const Model& model, const std::string& licen
         return Result<Processor>(Processor(raw_processor), ErrorCode::Success);
     }
 
-    return Result<Processor>(Processor(), to_cpp(rc));
+    return Result<Processor>(Processor(), static_cast<ErrorCode>(static_cast<int>(rc)));
 }
 
 Result<ProcessorContext> Processor::create_context() const
@@ -61,7 +61,8 @@ Result<ProcessorContext> Processor::create_context() const
         return Result<ProcessorContext>(ProcessorContext(raw_context), ErrorCode::Success);
     }
 
-    return Result<ProcessorContext>(ProcessorContext(), to_cpp(rc));
+    return Result<ProcessorContext>(ProcessorContext(),
+                                    static_cast<ErrorCode>(static_cast<int>(rc)));
 }
 
 Result<VadContext> Processor::create_vad_context() const
@@ -74,7 +75,7 @@ Result<VadContext> Processor::create_vad_context() const
         return Result<VadContext>(VadContext(raw_context), ErrorCode::Success);
     }
 
-    return Result<VadContext>(VadContext(), to_cpp(rc));
+    return Result<VadContext>(VadContext(), static_cast<ErrorCode>(static_cast<int>(rc)));
 }
 
 } // namespace aic

--- a/src/aic.cpp
+++ b/src/aic.cpp
@@ -33,15 +33,15 @@ Result<Model> Model::create_from_buffer(const uint8_t* buffer, size_t buffer_len
 
 Result<Processor> Processor::create(const Model& model, const std::string& license_key)
 {
-    static const bool wrapper_id_set = []() {
+    static const bool wrapper_id_set = []()
+    {
         aic_set_sdk_wrapper_id(1);
         return true;
     }();
     (void) wrapper_id_set;
 
     ::AicProcessor* raw_processor = nullptr;
-    ::AicErrorCode rc =
-        aic_processor_create(&raw_processor, model.model_, license_key.c_str());
+    ::AicErrorCode  rc = aic_processor_create(&raw_processor, model.model_, license_key.c_str());
 
     if (rc == AIC_ERROR_CODE_SUCCESS)
     {
@@ -54,7 +54,7 @@ Result<Processor> Processor::create(const Model& model, const std::string& licen
 Result<ProcessorContext> Processor::create_context() const
 {
     ::AicProcessorContext* raw_context = nullptr;
-    ::AicErrorCode rc = aic_processor_context_create(&raw_context, processor_);
+    ::AicErrorCode         rc          = aic_processor_context_create(&raw_context, processor_);
 
     if (rc == AIC_ERROR_CODE_SUCCESS)
     {


### PR DESCRIPTION
This release comes with a number of new features and several breaking changes. Most notably, the C library does no longer include any models, which significantly reduces the library's binary size. The models are now available separately for download at https://artifacts.ai-coustics.io.

**New license keys required**: License keys previously generated in the [developer portal](https://developers.ai-coustics.io) will no longer work. New license keys must be generated.

**Model naming changes**: Quail-STT models are now called "Quail" - These models are optimized for human-to-machine enhancement (e.g., Speech-to-Text (STT) applications). Quail models are now called "Sparrow" - These models are optimized for human-to-human enhancement (e.g., voice calls, conferencing). This naming change clarifies the distinction between STT-focused models and human-to-human communication model

**Major architectural changes**: The API has been restructured to separate model data from processing instances. What was previously called `aic::AicModel` (which handled both model data and processing) has been split into:
- `aic::Model`: Now represents only the ML model data loaded from files or memory
- `aic::Processor`: New type that performs the actual audio processing using a model
- Multiple processors can share the same model, allowing efficient resource usage across streams
- Models can be destroyed after creating processors; memory is freed when the last processor using them is destroyed
- To change parameters, reset the processor and get output delay, create a `aic::ProcessorContext`. This context can be freely moved between threads

**C++ wrapper alignment**: The C++ API mirrors these changes:
- `aic::Model` holds model data; `aic::Processor` performs processing using a model
- `aic::ProcessorContext` and `aic::VadContext` are created from a processor for thread-safe control APIs
- `aic::ProcessorConfig` helps construct optimal configs from a model

## New features

- Models now load from files via `aic::Model::create_from_file`.
- Models can also be created from in-memory buffers with `aic::Model::create_from_buffer`.
- Added `aic::Model::get_id` to query the id of a model.
- A single model instance can be shared across multiple processors.
- Added `aic::Processor::create` so each stream can be initialized independently from a shared model while sharing weights.
- Added `aic::get_compatible_model_version` to query the required model version for this SDK.
- Added context-based APIs for thread-safe control operations:
    - `aic::ProcessorContext` for processor control and queries
    - `aic::VadContext` for VAD control and queries
- Model query APIs moved to model methods:
    - `aic::Model::get_optimal_sample_rate` - gets optimal sample rate for a model
    - `aic::Model::get_optimal_num_frames` - gets optimal frame count for a model at given sample rate
- Added new error codes for model loading (see `aic::ErrorCode`):
    - `ErrorCode::ModelInvalid`
    - `ErrorCode::ModelVersionUnsupported`
    - `ErrorCode::ModelFilePathInvalid`
    - `ErrorCode::FileSystemError`
    - `ErrorCode::ModelDataUnaligned`
- C++ wrapper additions:
    - `aic::Model::create_from_file` and `aic::Model::create_from_buffer`
    - `aic::Processor::create` plus `aic::ProcessorContext` and `aic::VadContext`
    - `aic::Model::get_id`, `aic::Model::get_optimal_sample_rate`, `aic::Model::get_optimal_num_frames`
    - `aic::get_compatible_model_version` and `aic::get_sdk_version`
    - `aic::Result<T>` return type for error handling without exceptions

## Breaking changes

- License keys previously generated in the [development portal](developers.ai-coustics.io) will no longer work. New license keys have to be generated.
- Existing model-processing combined API has been split into `aic::Model` and `aic::Processor`.
- Removed `aic::ModelType` enum; callers must supply a model file or aligned buffer instead of selecting a built-in model.
- License keys are now provided to `aic::Processor::create` rather than model creation.
- Renamed `aic::Parameter` to `aic::ProcessorParameter`.
- VAD APIs now use `aic::VadContext` created from a processor.
- Processor control APIs now live on `aic::ProcessorContext` (reset, parameter access, output delay).
- Model query APIs now live on `aic::Model` (optimal sample rate/frames).
- C++ wrapper breaking changes:
    - `aic::AicModel` wrapper replaced by `aic::Model` + `aic::Processor`
    - Model selection by enum removed; supply a model file or aligned buffer
    - Parameter/reset/output delay APIs now live on `aic::ProcessorContext`
    - VAD APIs now use `aic::VadContext` created from a processor
    - `std::pair`/`std::unique_ptr` creation patterns replaced by `aic::Result<T>` + `take()`

## Fixes

- Improved thread safety.
- Fixed an issue where the allocated size for an FFT operation could be incorrect, leading to a crash.
